### PR TITLE
clickhouse_client: Remove timedelta support

### DIFF
--- a/plugins/modules/clickhouse_client.py
+++ b/plugins/modules/clickhouse_client.py
@@ -114,7 +114,6 @@ statistics:
   returned: on success
   type: dict
 '''
-from datetime import timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -154,7 +153,7 @@ def vals_to_supported(result):
     """
     for idx_row, row in enumerate(result):
         for idx_val, val in enumerate(row):
-            if is_uuid(val) or isinstance(val, timedelta):
+            if is_uuid(val):
                 # As tuple does not support change,
                 # we need some conversion here
                 result[idx_row] = replace_val_in_tuple(row, idx_val, str(val))


### PR DESCRIPTION
##### SUMMARY
clickhouse_client: Remove timedelta support. Reasons:
- There's a type interval that cannot be used as a column type
- Let's not optimize prematurely
- It also pulls an extra datetime lib loading