### PR TITLE
GHA: add testing against stable-2.17 to CI matrix

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -27,6 +27,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     steps:
 
@@ -59,6 +60,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
 
     steps:
@@ -103,6 +105,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
         clickhouse:
           - 21.8.15.7

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Tested with the following `ansible-core` releases:
 - 2.14
 - 2.15
 - 2.16
+- 2.17
 - current development version
 
 Tested with ClickHouse:


### PR DESCRIPTION
##### SUMMARY
As stable-2.18 of ansible-core has been recently branched, add testing against stable-2.17 to CI matrix