### PR TITLE
added option to disable flatten nested

### DIFF
--- a/plugins/doc_fragments/client_inst_opts.py
+++ b/plugins/doc_fragments/client_inst_opts.py
@@ -49,6 +49,14 @@ options:
     type: dict
     default: {}
 
+  flatten_nested:
+    description:
+      - Updates flatten_nested setting on session before running
+        query
+      - Only runs the update if set to 0
+    type: int
+    default: 1
+
 requirements: [ 'clickhouse-driver' ]
 
 notes:

--- a/plugins/doc_fragments/client_inst_opts.py
+++ b/plugins/doc_fragments/client_inst_opts.py
@@ -51,12 +51,10 @@ options:
 
   flatten_nested:
     description:
-      - Updates flatten_nested setting on session before running
-        query
-      - Only runs the update if set to 0
+      - Sets the C(flatten_nested) setting on session before running the query.
     type: int
-    default: 1
-
+    choices: [0, 1]
+    version_added: '0.5.0'
 requirements: [ 'clickhouse-driver' ]
 
 notes:

--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -37,7 +37,7 @@ def client_common_argument_spec():
         login_user=dict(type='str', default=None),
         login_password=dict(type='str', default=None, no_log=True),
         client_kwargs=dict(type='dict', default={}),
-        flatten_nested=dict(type='int'),
+        flatten_nested=dict(type='int', choices=[0, 1]),
     )
 
 

--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -37,6 +37,7 @@ def client_common_argument_spec():
         login_user=dict(type='str', default=None),
         login_password=dict(type='str', default=None, no_log=True),
         client_kwargs=dict(type='dict', default={}),
+        flatten_nested=dict(type='int', default=1),
     )
 
 

--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -37,7 +37,7 @@ def client_common_argument_spec():
         login_user=dict(type='str', default=None),
         login_password=dict(type='str', default=None, no_log=True),
         client_kwargs=dict(type='dict', default={}),
-        flatten_nested=dict(type='int', default=1),
+        flatten_nested=dict(type='int'),
     )
 
 

--- a/plugins/modules/clickhouse_client.py
+++ b/plugins/modules/clickhouse_client.py
@@ -285,7 +285,7 @@ def main():
 
     # Execute query
     if flatten_nested == 0:
-        execute_query(module, client, "set flatten_nested=0;", execute_kwargs)
+        execute_query(module, client, "SET flatten_nested = 0", execute_kwargs)
     result = execute_query(module, client, query, execute_kwargs)
 
     # Convert values not supported by ansible-core

--- a/plugins/modules/clickhouse_client.py
+++ b/plugins/modules/clickhouse_client.py
@@ -260,6 +260,7 @@ def main():
     client_kwargs = module.params['client_kwargs']
     query = module.params['execute']
     execute_kwargs = module.params['execute_kwargs']
+    flatten_nested = module.params['flatten_nested']
     # The reason why these arguments are separate from client_kwargs
     # is that we need to protect some sensitive data like passwords passed
     # to the module from logging (see the arguments above with no_log=True);
@@ -283,6 +284,8 @@ def main():
     substituted_query = get_substituted_query(module, client, query, execute_kwargs)
 
     # Execute query
+    if flatten_nested == 0:
+        execute_query(module, client, "set flatten_nested=0;", execute_kwargs)
     result = execute_query(module, client, query, execute_kwargs)
 
     # Convert values not supported by ansible-core

--- a/tests/integration/targets/clickhouse_client/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_client/tasks/initial.yml
@@ -71,3 +71,25 @@
   ansible.builtin.assert:
     that:
     - result.result == [["one"], ["two"], ["three"]]
+
+- name: Load a Schema with Nested Fields
+  community.clickhouse.clickhouse_client:
+    flatten_nested: 0
+    execute: "CREATE TABLE foo.nested ( `coordinates` Nested(x int, y int )) ENGINE = Memory;"
+
+- name: Load Nested Data
+  community.clickhouse.clickhouse_client:
+    execute: 'insert into foo.nested (coordinates) VALUES (([(10,20), (11,21)]));'
+
+- name: Read Nested data
+  register: nested_result
+  community.clickhouse.clickhouse_client:
+    execute: 'select * from foo.nested;'
+
+- name: Check Nested Data exists
+  ansible.builtin.assert:
+    that:
+    - nested_result.result[0][0][0][0] == 10
+    - nested_result.result[0][0][0][1] == 20
+    - nested_result.result[0][0][1][0] == 11
+    - nested_result.result[0][0][1][1] == 21


### PR DESCRIPTION
##### SUMMARY
I could not find a way to run multiple queries from the same context using this module. There's no way to create a table with `flatten_nested` disabled without running multiple queries. This PR adds a field called `flatten_nested` for `clickhouse_client` that sets this setting before running the query. 


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Flatten Nested

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This is clickhouse's document explaining options for nested fields: https://clickhouse.com/docs/en/sql-reference/data-types/nested-data-structures/nested. The behavior with `flatten_nested` enabled and disabled is explained there. The only way to disable it is by running `set flatten_nested=0;` before creating a table.

