### PR TITLE
add quotes to DCL queries around username

### DIFF
--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -272,7 +272,7 @@ class ClickHouseUser():
     def create(self, type_password, password, cluster, settings,
                roles, roles_mode, default_roles, default_roles_mode):
 
-        query = "CREATE USER %s" % self.name
+        query = "CREATE USER '%s'" % self.name
 
         if password is not None:
             query += (" IDENTIFIED WITH %s BY '%s'") % (type_password, password)
@@ -316,7 +316,7 @@ class ClickHouseUser():
         return self.changed
 
     def drop(self, cluster):
-        query = "DROP USER %s" % self.name
+        query = "DROP USER '%s'" % self.name
         if cluster:
             query += " ON CLUSTER %s" % cluster
 
@@ -382,7 +382,7 @@ class ClickHouseUser():
         # If update_password is always
         # TODO: When ClickHouse will allow to retrieve password hashes,
         # make this idempotent, i.e. execute this only if the passwords don't match
-        query = ("ALTER USER %s IDENTIFIED WITH %s "
+        query = ("ALTER USER '%s' IDENTIFIED WITH %s "
                  "BY '%s'") % (self.name, type_pwd, pwd)
         if cluster:
             query += " ON CLUSTER %s" % cluster
@@ -395,7 +395,7 @@ class ClickHouseUser():
         self.changed = True
 
     def __grant_roles(self, roles_to_set, cluster):
-        query = "GRANT %s TO %s" % (', '.join(roles_to_set), self.name)
+        query = "GRANT %s TO '%s'" % (', '.join(roles_to_set), self.name)
         executed_statements.append(query)
 
         if cluster:
@@ -407,7 +407,7 @@ class ClickHouseUser():
         self.changed = True
 
     def __revoke_roles(self, roles_to_revoke, cluster):
-        query = "REVOKE %s FROM %s" % (', '.join(roles_to_revoke), self.name)
+        query = "REVOKE %s FROM '%s'" % (', '.join(roles_to_revoke), self.name)
         executed_statements.append(query)
 
         if cluster:
@@ -424,7 +424,7 @@ class ClickHouseUser():
             if role not in self.current_roles and role not in self.module.params["roles"]:
                 self.module.fail_json("User %s is not in %s role. Grant it explicitly first." % (self.name, role))
 
-        query = "ALTER USER %s DEFAULT ROLE %s" % (self.name, ', '.join(roles_to_set))
+        query = "ALTER USER '%s' DEFAULT ROLE %s" % (self.name, ', '.join(roles_to_set))
         if cluster:
             query += " ON CLUSTER %s" % cluster
         executed_statements.append(query)
@@ -435,7 +435,7 @@ class ClickHouseUser():
         self.changed = True
 
     def __unset_default_roles(self):
-        query = "SET DEFAULT ROLE NONE TO %s" % self.name
+        query = "SET DEFAULT ROLE NONE TO '%s'" % self.name
         executed_statements.append(query)
 
         if not self.module.check_mode:

--- a/tests/integration/targets/clickhouse_user/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_user/tasks/initial.yml
@@ -15,7 +15,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE USER test_user IDENTIFIED WITH sha256_password BY '********'"]
+    - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH sha256_password BY '********'"]
 
 - name: Check the actual state
   register: result
@@ -107,7 +107,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER USER test_user IDENTIFIED WITH sha256_password BY '********'"]
+    - result.executed_statements == ["ALTER USER 'test_user' IDENTIFIED WITH sha256_password BY '********'"]
 
 - name: Drop test_user
   community.clickhouse.clickhouse_user:
@@ -157,8 +157,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant, manager TO test_user" or result.executed_statements[0] == "GRANT manager, accountant TO test_user"
-    - result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE manager, accountant"
+    - result.executed_statements[0] == "GRANT accountant, manager TO 'test_user'" or result.executed_statements[0] == "GRANT manager, accountant TO 'test_user'"
+    - result.executed_statements[1] == "ALTER USER 'test_user DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE manager, accountant"
 
 - name: Check the actual state
   register: result
@@ -188,8 +188,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant, manager TO test_user" or result.executed_statements[0] == "GRANT manager, accountant TO test_user"
-    - result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE manager, accountant"
+    - result.executed_statements[0] == "GRANT accountant, manager TO 'test_user'" or result.executed_statements[0] == "GRANT manager, accountant TO 'test_user'"
+    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE manager, accountant"
 
 - name: Check the actual state
   register: result
@@ -218,9 +218,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT sales TO test_user"
-    - result.executed_statements[1] == "REVOKE accountant, manager FROM test_user" or result.executed_statements[1] == "REVOKE manager, accountant FROM test_user"
-    - result.executed_statements[2] == "ALTER USER test_user DEFAULT ROLE sales"
+    - result.executed_statements[0] == "GRANT sales TO 'test_user'"
+    - result.executed_statements[1] == "REVOKE accountant, manager FROM 'test_user'" or result.executed_statements[1] == "REVOKE manager, accountant FROM 'test_user'"
+    - result.executed_statements[2] == "ALTER USER 'test_user' DEFAULT ROLE sales"
 
 - name: Check the actual state
   register: result
@@ -246,9 +246,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT sales TO test_user"
-    - result.executed_statements[1] == "REVOKE accountant, manager FROM test_user" or result.executed_statements[1] == "REVOKE manager, accountant FROM test_user"
-    - result.executed_statements[2] == "ALTER USER test_user DEFAULT ROLE sales"
+    - result.executed_statements[0] == "GRANT sales TO 'test_user'"
+    - result.executed_statements[1] == "REVOKE accountant, manager FROM 'test_user'" or result.executed_statements[1] == "REVOKE manager, accountant FROM 'test_user'"
+    - result.executed_statements[2] == "ALTER USER 'test_user' DEFAULT ROLE sales"
 
 - name: Check the actual state
   register: result
@@ -311,8 +311,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant TO test_user"
-    - result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE sales, accountant" or result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE accountant, sales"
+    - result.executed_statements[0] == "GRANT accountant TO 'test_user'"
+    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE sales, accountant" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant, sales"
 
 - name: Check the actual state
   register: result
@@ -338,7 +338,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO test_user"
+    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO 'test_user'"
 
 - name: Check the actual state
   register: result
@@ -363,7 +363,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO test_user"
+    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO 'test_user'"
 
 - name: Check the actual state
   register: result
@@ -389,7 +389,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE accountant, sales FROM test_user" or result.executed_statements[0] == "REVOKE sales, accountant FROM test_user"
+    - result.executed_statements[0] == "REVOKE accountant, sales FROM 'test_user'" or result.executed_statements[0] == "REVOKE sales, accountant FROM 'test_user'"
 
 - name: Check the actual state
   register: result
@@ -414,7 +414,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE accountant, sales FROM test_user" or result.executed_statements[0] == "REVOKE sales, accountant FROM test_user"
+    - result.executed_statements[0] == "REVOKE accountant, sales FROM 'test_user'" or result.executed_statements[0] == "REVOKE sales, accountant FROM 'test_user'"
 
 - name: Check the actual state
   register: result
@@ -510,8 +510,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE manager FROM test_user"
-    - result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE accountant"
+    - result.executed_statements[0] == "REVOKE manager FROM 'test_user'"
+    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant"
 
 - name: Check the actual state
   register: result
@@ -541,8 +541,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE manager FROM test_user"
-    - result.executed_statements[1] == "ALTER USER test_user DEFAULT ROLE accountant"
+    - result.executed_statements[0] == "REVOKE manager FROM 'test_user'"
+    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant"
 
 - name: Check the actual state
   register: result
@@ -603,9 +603,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "CREATE USER test_user_1"
-    - result.executed_statements[1] == "GRANT test_listed_only TO test_user_1"
-    - result.executed_statements[2] == "ALTER USER test_user_1 DEFAULT ROLE test_listed_only"
+    - result.executed_statements[0] == "CREATE USER 'test_user_1'"
+    - result.executed_statements[1] == "GRANT test_listed_only TO 'test_user_1'"
+    - result.executed_statements[2] == "ALTER USER 'test_user_1' DEFAULT ROLE test_listed_only"
 
 - name: Check the actual state
   register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

I added single quotes around the username in the DCL queries in clickhouse_user module.

In clickhouse DCL queries Names of users shoud be enclosed in single quotation marks.
Without this PR's fix it's impossible to create users with points (e.g. tralalero.tralala) because `%s` is not enclosed in single quotation marks.
Considering that there are queries where name is enclosed (https://github.com/ansible-collections/community.clickhouse/blob/main/plugins/modules/clickhouse_user.py#L250) I suppose this is bug / typo.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

clickhouse_user module
