### PR TITLE
actions/run-galaxy-importer: tell it not to build a container for ansible-test

### DIFF
--- a/.github/actions/run-galaxy-importer/action.yml
+++ b/.github/actions/run-galaxy-importer/action.yml
@@ -23,7 +23,7 @@ runs:
         cat <<EOF > galaxy-importer.cfg
         [galaxy-importer]
         RUN_ANSIBLE_TEST = True
-        ANSIBLE_TEST_LOCAL_IMAGE = True
+        ANSIBLE_TEST_LOCAL_IMAGE = False
         LOCAL_IMAGE_DOCKER = False
         EOF
 

--- a/.github/actions/run-galaxy-importer/action.yml
+++ b/.github/actions/run-galaxy-importer/action.yml
@@ -24,7 +24,6 @@ runs:
         [galaxy-importer]
         RUN_ANSIBLE_TEST = True
         ANSIBLE_TEST_LOCAL_IMAGE = False
-        LOCAL_IMAGE_DOCKER = False
         EOF
 
     - name: Build collection artifact


### PR DESCRIPTION
##### SUMMARY
actions/run-galaxy-importer: tell it not to build a container for ansible-test