### PR TITLE
chore: replace deprecated module_utils._text

### DIFF
--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 Client = None
 try:

--- a/plugins/modules/clickhouse_client.py
+++ b/plugins/modules/clickhouse_client.py
@@ -137,7 +137,7 @@ except ImportError:
 from uuid import UUID
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse import (
     check_clickhouse_driver,


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text is marked as deprecated. In 2.24(probably end of this year) will be removed. Use recomended replacement instead module_utils.common.text.converters.

##### ISSUE TYPE
- chore
