### PR TITLE
feat(spec): add success_on parameter for errors

### DIFF
--- a/changelogs/fragments/117-rewrite-error-handling.yml
+++ b/changelogs/fragments/117-rewrite-error-handling.yml
@@ -5,5 +5,4 @@ minor_changes:
     was always treated as success with no way to disable this behavior.
     Old behavior is preserved by default.
     It is now possible to control which error codes are treated as
-    success using the new ``success_on`` parameter
-   [](https://github.com/ansible-collections/community.clickhouse/issues/117).
+    success using the new ``success_on`` parameter (https://github.com/ansible-collections/community.clickhouse/issues/117).

--- a/changelogs/fragments/117-rewrite-error-handling.yml
+++ b/changelogs/fragments/117-rewrite-error-handling.yml
@@ -1,0 +1,9 @@
+---
+minor_changes:
+  - clickhouse_client - Change how server errors are handled.
+    Previously, error code 497 (ACCESS_DENIED / not enough privileges)
+    was always treated as success with no way to disable this behavior.
+    Old behavior is preserved by default.
+    It is now possible to control which error codes are treated as
+    success using the new ``success_on`` parameter
+   [](https://github.com/ansible-collections/community.clickhouse/issues/117).

--- a/plugins/doc_fragments/client_inst_opts.py
+++ b/plugins/doc_fragments/client_inst_opts.py
@@ -52,8 +52,7 @@ options:
   success_on:
     version_added: "2.2.0"
     description:
-      - List of server error codes that will be treated as success.
-        https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+      - List of L(server error codes,https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp)  that will be treated as success, otherwise throw errors.
     type: list
     elements: int
     default: [497]

--- a/plugins/doc_fragments/client_inst_opts.py
+++ b/plugins/doc_fragments/client_inst_opts.py
@@ -52,7 +52,8 @@ options:
   success_on:
     version_added: "2.2.0"
     description:
-      - List of L(server error codes,https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp)  that will be treated as success, otherwise throw errors.
+      - List of L(server error codes,https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp)
+        that will be treated as success, otherwise throw errors.
     type: list
     elements: int
     default: [497]

--- a/plugins/doc_fragments/client_inst_opts.py
+++ b/plugins/doc_fragments/client_inst_opts.py
@@ -49,6 +49,15 @@ options:
     type: dict
     default: {}
 
+  success_on:
+    version_added: "2.2.0"
+    description:
+      - List of server error codes that will be treated as success.
+        https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+    type: list
+    elements: int
+    default: [497]
+
 requirements: [ 'clickhouse-driver' ]
 
 notes:

--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -16,12 +16,11 @@ from ansible.module_utils.common.text.converters import to_native
 Client = None
 try:
     from clickhouse_driver import Client
+    from clickhouse_driver.errors import ServerException
     from clickhouse_driver import __version__ as driver_version
     HAS_DB_DRIVER = True
 except ImportError:
     HAS_DB_DRIVER = False
-
-PRIV_ERR_CODE = 497
 
 
 def client_common_argument_spec():
@@ -37,6 +36,7 @@ def client_common_argument_spec():
         login_user=dict(type='str', default=None),
         login_password=dict(type='str', default=None, no_log=True),
         client_kwargs=dict(type='dict', default={}),
+        success_on=dict(type='list', elements='int', default=[497]),
     )
 
 
@@ -110,11 +110,16 @@ def execute_query(module, client, query, execute_kwargs=None, set_settings=None)
             for setting in set_settings:
                 client.execute("SET %s = '%s'" % (setting, set_settings[setting]))
         result = client.execute(query, **execute_kwargs)
-    except Exception as e:
-        if "Not enough privileges" in to_native(e):
-            return PRIV_ERR_CODE
-        module.fail_json(msg="Failed to execute query: %s" % to_native(e))
-
+    except ServerException as e:
+        if e.code in module.params['success_on']:
+            module.exit_json(changed=False, msg="Code %i defined as success." % e.code)
+        module.fail_json(
+            msg="Failed to execute query.",
+            exception=to_native(e),
+            code=e.code,
+            message=e.message,
+            query=query
+        )
     return result
 
 
@@ -124,9 +129,6 @@ def get_server_version(module, client):
     Returns a dictionary with server version.
     """
     result = execute_query(module, client, "SELECT version()")
-
-    if result == PRIV_ERR_CODE:
-        return {PRIV_ERR_CODE: "Not enough privileges"}
 
     raw = result[0][0]
     split_raw = raw.split('.')

--- a/plugins/modules/clickhouse_grants.py
+++ b/plugins/modules/clickhouse_grants.py
@@ -192,7 +192,6 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     get_main_conn_kwargs,
 )
 
-PRIV_ERR_CODE = 497
 executed_statements = []
 
 # Compile regex pattern once for performance
@@ -215,24 +214,11 @@ class ClickHouseGrants():
                  "SELECT 1 FROM system.roles WHERE name = '%s' "
                  "LIMIT 1" % (self.grantee, self.grantee))
 
-        result = execute_query(self.module, self.client, query)
-
-        if result == PRIV_ERR_CODE:
-            login_user = self.module.params['login_user']
-            msg = "Not enough privileges for user: %s" % login_user
-            self.module.fail_json(msg=msg)
-
-        if not result:
-            self.module.fail_json(msg="Grantee %s does not exist" % self.grantee)
+        execute_query(self.module, self.client, query)
 
     def get(self):
         query = "SHOW GRANTS FOR '%s'" % self.grantee
         result = execute_query(self.module, self.client, query)
-
-        if result == PRIV_ERR_CODE:
-            login_user = self.module.params['login_user']
-            msg = "Not enough privileges for user: %s to SHOW GRANTS" % login_user
-            self.module.fail_json(msg=msg)
 
         grants = {}
         for row in result:

--- a/plugins/modules/clickhouse_grants.py
+++ b/plugins/modules/clickhouse_grants.py
@@ -214,7 +214,10 @@ class ClickHouseGrants():
                  "SELECT 1 FROM system.roles WHERE name = '%s' "
                  "LIMIT 1" % (self.grantee, self.grantee))
 
-        execute_query(self.module, self.client, query)
+        result = execute_query(self.module, self.client, query)
+
+        if not result:
+            self.module.fail_json(msg="Grantee %s does not exist" % self.grantee)
 
     def get(self):
         query = "SHOW GRANTS FOR '%s'" % self.grantee

--- a/plugins/modules/clickhouse_info.py
+++ b/plugins/modules/clickhouse_info.py
@@ -181,9 +181,6 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
 )
 
 
-PRIV_ERR_CODE = 497
-
-
 def get_databases(module, client):
     """Get databases.
 
@@ -192,9 +189,6 @@ def get_databases(module, client):
     query = ("SELECT name, engine, data_path, metadata_path, uuid, "
              "engine_full, comment FROM system.databases")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     db_info = {}
     for row in result:
@@ -219,9 +213,6 @@ def get_clusters(module, client):
              "host_address, port, is_local, user, default_database, errors_count, "
              "slowdowns_count, estimated_recovery_time FROM system.clusters")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     cluster_info = {}
 
@@ -276,9 +267,6 @@ def get_roles(module, client):
     query = "SELECT name, id, storage FROM system.roles"
     result = execute_query(module, client, query)
 
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
-
     roles_info = {}
     for row in result:
         role_name = row[0]
@@ -305,9 +293,6 @@ def get_tables(module, client):
              "has_own_data, loading_dependencies_database, loading_dependencies_table, "
              "loading_dependent_database, loading_dependent_table FROM system.tables")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     tables_info = {}
     for row in result:
@@ -362,9 +347,6 @@ def get_dictionaries(module, client):
              "loading_duration, last_exception, comment FROM system.dictionaries")
     result = execute_query(module, client, query)
 
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
-
     dictionaries_info = {}
     for row in result:
         dict_database = row[0] if row[0] else 'dict'
@@ -406,9 +388,6 @@ def get_settings(module, client):
              "type, default, alias_for FROM system.settings")
     result = execute_query(module, client, query)
 
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
-
     settings_info = {}
     for row in result:
         settings_info[row[0]] = {
@@ -435,9 +414,6 @@ def get_merge_tree_settings(module, client):
              "readonly, type FROM system.merge_tree_settings")
     result = execute_query(module, client, query)
 
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
-
     merge_tree_settings_info = {}
     for row in result:
         merge_tree_settings_info[row[0]] = {
@@ -463,9 +439,6 @@ def get_users(module, client):
              "default_roles_list, default_roles_except, grantees_any, "
              "grantees_list, grantees_except, default_database FROM system.users")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     user_info = {}
     for row in result:
@@ -525,9 +498,6 @@ def get_settings_profiles(module, client):
              "apply_to_except FROM system.settings_profiles")
     result = execute_query(module, client, query)
 
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
-
     profile_info = {}
     for row in result:
         profile_info[row[0]] = {
@@ -550,9 +520,6 @@ def get_quotas(module, client):
     query = ("SELECT name, id, storage, keys, durations, apply_to_all, "
              "apply_to_list, apply_to_except FROM system.quotas")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     quota_info = {}
     for row in result:
@@ -578,9 +545,6 @@ def get_all_grants(module, client):
              "table, column, is_partial_revoke, grant_option FROM system.grants")
 
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     grants_info = {
         'users': {},
@@ -620,9 +584,6 @@ def get_settings_profile_elements(module, client):
              "index, setting_name, value, min, max, writability, "
              "inherit_profile FROM system.settings_profile_elements")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     settings_profile_elements = {'profiles': {},
                                  'users': {},
@@ -668,9 +629,6 @@ def get_storage_policies(module, client):
              "disks, volume_type, max_data_part_size, "
              "move_factor, prefer_not_to_merge FROM system.storage_policies")
     result = execute_query(module, client, query)
-
-    if result == PRIV_ERR_CODE:
-        return {str(PRIV_ERR_CODE): "Not enough privileges"}
 
     storage_policies_info = {}
     for row in result:

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -343,7 +343,6 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     get_main_conn_kwargs,
 )
 
-PRIV_ERR_CODE = 497
 executed_statements = []
 
 
@@ -370,11 +369,6 @@ class ClickHouseUser():
                  "WHERE name = '%s'" % self.name)
 
         result = execute_query(self.module, self.client, query)
-
-        if result == PRIV_ERR_CODE:
-            login_user = self.module.params['login_user']
-            msg = "Not enough privileges for user: %s" % login_user
-            self.module.fail_json(msg=msg)
 
         if result != []:
             self.user_exists = True

--- a/tests/integration/targets/clickhouse_client/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_client/tasks/initial.yml
@@ -19,7 +19,7 @@
     - result is changed
     - result.result != []
 
-- name: Create dabase
+- name: Create database
   community.clickhouse.clickhouse_client:
     execute: CREATE DATABASE foo
 

--- a/tests/integration/targets/clickhouse_grants/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_grants/tasks/initial.yml
@@ -79,7 +79,7 @@
   ansible.builtin.assert:
     that:
     - result is failed
-    - result.code == 511
+    - result.msg == 'Grantee notexists does not exist'
 
 - name: Grant initial privileges to alice
   register: result

--- a/tests/integration/targets/clickhouse_grants/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_grants/tasks/initial.yml
@@ -79,7 +79,7 @@
   ansible.builtin.assert:
     that:
     - result is failed
-    - result.msg is search("does not exist")
+    - result.code == 511
 
 - name: Grant initial privileges to alice
   register: result

--- a/tests/integration/targets/clickhouse_info/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_info/tasks/initial.yml
@@ -82,7 +82,23 @@
 - name: Check it returned something
   ansible.builtin.assert:
     that:
-    - result["users"]["497"] == "Not enough privileges"
+    - result.changed == false
+    - result.failed == false
+
+- name: Query DB using non-default connect params disabling default success_on
+  register: result
+  ignore_errors: true
+  community.clickhouse.clickhouse_info:
+    login_host: localhost
+    login_user: alice
+    login_password: my_password
+    success_on: []
+
+- name: Check exception
+  ansible.builtin.assert:
+    that:
+    - result.code == 497
+    - "result.message is match('^DB::Exception: alice: Not enough privileges')"
 
 - name: Limit gathered values, one value does not exist
   register: result

--- a/tests/unit/plugins/module_utils/test_clickhouse.py
+++ b/tests/unit/plugins/module_utils/test_clickhouse.py
@@ -24,6 +24,7 @@ class FakeAnsibleModule:
             "login_db": None,
             "login_password": None,
             "client_kwargs": {},
+            "success_on": [497],
         }
 
     def fail_json(self, msg):
@@ -37,7 +38,8 @@ def test_client_common_argument_spec():
         'login_user': {'type': 'str', 'default': None},
         'login_host': {'type': 'str', 'default': 'localhost'},
         'login_password': {'type': 'str', 'default': None, 'no_log': True},
-        'client_kwargs': {'type': 'dict', 'default': {}}
+        'client_kwargs': {'type': 'dict', 'default': {}},
+        'success_on': {'type': 'list', 'elements': 'int', 'default': [497]},
     }
 
     assert client_common_argument_spec() == EXPECTED


### PR DESCRIPTION
##### SUMMARY
Previously execute_query only treated code 497 (ACCESS_DENIED) as non-fatal and returned it. All other errors called fail_json immediately. This could cause tasks to silently succeed when they should have failed if the module did not explicitly handle the returned code.

Error handling is now fully inside execute_query. If the error code is present in the new success_on list, the module exits without error. Otherwise it calls fail_json.

fail_json now also includes separate code and message fields. Default for success_on is [497] to keep backward
compatibility.

Fixes #117 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
argument_spec
