### PR TITLE
feat(clickhouse_db): support for change db comment

### DIFF
--- a/changelogs/fragments/189-support-alter-database-comment.yml
+++ b/changelogs/fragments/189-support-alter-database-comment.yml
@@ -1,0 +1,3 @@
+---
+  minor_changes:
+    - clickhouse_db - support for changing database comment. Required server version 25.8(https://github.com/ansible-collections/community.clickhouse/issues/189).

--- a/changelogs/fragments/189-support-alter-database-comment.yml
+++ b/changelogs/fragments/189-support-alter-database-comment.yml
@@ -1,3 +1,3 @@
 ---
   minor_changes:
-    - clickhouse_db - support for changing database comment. Required server version 25.8(https://github.com/ansible-collections/community.clickhouse/issues/189).
+    - clickhouse_db - support for changing database comment. Requires ClickHouse server version >= 25.8 (https://github.com/ansible-collections/community.clickhouse/issues/189).

--- a/plugins/modules/clickhouse_db.py
+++ b/plugins/modules/clickhouse_db.py
@@ -65,7 +65,7 @@ options:
   comment:
     description:
       - Database comment.
-      - Since 2.2.0 can change comments in existing databases(required server 25.8 or later).
+      - Since C(2.2.0) can change comments in existing databases (requires server 25.8 or later).
     type: str
     version_added: '0.4.0'
 '''

--- a/plugins/modules/clickhouse_db.py
+++ b/plugins/modules/clickhouse_db.py
@@ -27,6 +27,7 @@ version_added: '0.3.0'
 author:
   - Andrew Klychkov (@Andersson007)
   - Aleksandr Vagachev (@aleksvagachev)
+  - Rafal Kozlowski (@rkozlo)
 
 extends_documentation_fragment:
   - community.clickhouse.client_inst_opts
@@ -63,7 +64,8 @@ options:
     version_added: '0.4.0'
   comment:
     description:
-      - Database comment. Once set, cannot be changed.
+      - Database comment.
+      - Since 2.2.0 can change comments in existing databases(required server 25.8 or later).
     type: str
     version_added: '0.4.0'
 '''
@@ -131,7 +133,7 @@ executed_statements = []
 
 
 class ClickHouseDB():
-    def __init__(self, module, client, name, cluster):
+    def __init__(self, module, client, name, cluster, comment):
         self.module = module
         self.client = client
         self.name = name
@@ -140,7 +142,7 @@ class ClickHouseDB():
         # Set default values, then update
         self.exists = False
         self.engine = None
-        self.comment = None
+        self.comment = comment
         self.__populate_info()
 
     def __populate_info(self):
@@ -198,12 +200,31 @@ class ClickHouseDB():
                    "in order to change it." % (engine, self.engine))
             self.module.warn(msg)
 
+        # At this moment ALTER DATABASE supports only MODIFY COMMENT.
+        # When it will support more options probably better
+        # will be moving query builder above and here only link comment.
         if comment and comment != self.comment:
-            msg = ("The provided comment '%s' is different from "
-                   "the current one '%s'. It is NOT possible to "
-                   "change it. The recreation of the database is required "
-                   "in order to change it." % (comment, self.comment))
-            self.module.warn(msg)
+            if self.srv_version['year'] < 22:
+                msg = ('The module supports the comment feature for ClickHouse '
+                       'versions equal to or higher than 22.*. Ignored.')
+                self.module.warn(msg)
+            elif (self.srv_version['year'] == 25 and self.srv_version['feature'] >= 8) or self.srv_version['year'] >= 26:
+                query = "ALTER DATABASE %s" % self.name
+                if self.cluster:
+                    query += " ON CLUSTER %s" % self.cluster
+                query += " MODIFY COMMENT '%s'" % comment
+
+                executed_statements.append(query)
+
+                if not self.module.check_mode:
+                    execute_query(self.module, self.client, query)
+
+                return True
+            else:
+                self.module.warn(
+                    f"Server version {self.srv_version['year']}.{self.srv_version['feature']} "
+                    f"does not support MODIFY COMMENT. Required: 25.8 or higher"
+                )
 
         return False
 
@@ -275,13 +296,7 @@ def main():
 
     # Do the job
     changed = False
-    database = ClickHouseDB(module, client, name, cluster)
-
-    if comment and database.srv_version['year'] < 22:
-        msg = ('The module supports the comment feature for ClickHouse '
-               'versions equal to or higher than 22.*. Ignored.')
-        module.warn(msg)
-        comment = None
+    database = ClickHouseDB(module, client, name, cluster, comment)
 
     if state == 'present':
         if not database.exists:
@@ -293,7 +308,7 @@ def main():
         if database.exists:
             changed = database.rename(target)
         else:
-            target_db = ClickHouseDB(module, client, target, cluster)
+            target_db = ClickHouseDB(module, client, target, cluster, comment)
             if target_db.exists:
                 changed = False
                 msg = "There is nothing to rename"

--- a/tests/integration/targets/clickhouse_db/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_db/tasks/initial.yml
@@ -361,6 +361,16 @@
             - result is changed
             - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
 
+      - name: Check the actual state
+        register: result
+        community.clickhouse.clickhouse_client:
+          execute: "SELECT comment FROM system.databases WHERE name = 'test_db'"
+
+      - name: Check if the comment hasn't changed
+        ansible.builtin.assert:
+          that:
+          - result.result == [['Test DB']]
+
       - name: Create database with another comment real mode
         register: result
         community.clickhouse.clickhouse_db:
@@ -373,6 +383,16 @@
           that:
           - result is changed
           - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
+
+      - name: Check the actual state
+        register: result
+        community.clickhouse.clickhouse_client:
+          execute: "SELECT comment FROM system.databases WHERE name = 'test_db'"
+
+      - name: Check if the comment has changed
+        ansible.builtin.assert:
+          that:
+            - result.result == [['Test DB 1']]
 
       - name: Create database with another comment real mode - idempotency
         register: result
@@ -412,6 +432,16 @@
             - result is not changed
             - result.executed_statements == []
 
+      - name: Check the actual state
+        register: result
+        community.clickhouse.clickhouse_client:
+          execute: "SELECT comment FROM system.databases WHERE name = 'test_db'"
+
+      - name: Check if the comment hasn't changed
+        ansible.builtin.assert:
+          that:
+            - result.result == [['Test DB']]
+
       - name: Create database with another comment real mode - should end with warn
         register: result
         community.clickhouse.clickhouse_db:
@@ -424,6 +454,16 @@
           that:
             - result is not changed
             - result.executed_statements == []
+
+      - name: Check the actual state
+        register: result
+        community.clickhouse.clickhouse_client:
+          execute: "SELECT comment FROM system.databases WHERE name = 'test_db'"
+
+      - name: Check if the comment hasn't changed
+        ansible.builtin.assert:
+          that:
+            - result.result == [['Test DB']]
 
   - name: Check the actual state
     register: result

--- a/tests/integration/targets/clickhouse_db/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_db/tasks/initial.yml
@@ -340,20 +340,90 @@
       that:
       - result.result == [['Test DB']]
 
-  # Test
-  # The change is not possible. It'll just show a warning and ignore
-  - name: Create database with another comment real mode
-    register: result
-    community.clickhouse.clickhouse_db:
-      state: present
-      name: test_db
-      comment: Test DB 1
+  - name: Test post 25.8 behaviour alter database modify comment
+    when: >
+      (server_info['version']['year'] == 25 and server_info['version']['feature'] | int >= 8)
+      or
+      server_info['version']['year'] | int > 25
+    block:
 
-  - name: Check ret values
-    ansible.builtin.assert:
-      that:
-      - result is not changed
-      - result.executed_statements == []
+      - name: Create database with another comment check mode
+        register: result
+        check_mode: true
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB 1
+
+      - name: Check ret values
+        ansible.builtin.assert:
+          that:
+            - result is changed
+            - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
+
+      - name: Create database with another comment real mode
+        register: result
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB 1
+
+      - name: Check ret values
+        ansible.builtin.assert:
+          that:
+          - result is changed
+          - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
+
+      - name: Create database with another comment real mode - idempotency
+        register: result
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB 1
+
+      - name: Check ret values
+        ansible.builtin.assert:
+          that:
+          - result is not changed
+
+      - name: Set database comment to original value
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB
+
+  - name: Test pre 25.8 behaviour alter database modify comment
+    when: >
+        (server_info['version']['year'] | int == 25 and server_info['version']['feature'] | int < 8)
+        or
+        server_info['version']['year'] | int < 25
+    block:
+      - name: Create database with another comment check mode - should end with warn
+        register: result
+        check_mode: true
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB 1
+
+      - name: Check ret values
+        ansible.builtin.assert:
+          that:
+            - result is not changed
+            - result.executed_statements == []
+
+      - name: Create database with another comment real mode - should end with warn
+        register: result
+        community.clickhouse.clickhouse_db:
+          state: present
+          name: test_db
+          comment: Test DB 1
+
+      - name: Check ret values
+        ansible.builtin.assert:
+          that:
+            - result is not changed
+            - result.executed_statements == []
 
   - name: Check the actual state
     register: result

--- a/tests/unit/plugins/modules/test_clickhouse_db.py
+++ b/tests/unit/plugins/modules/test_clickhouse_db.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import, division, print_function
+import pytest
+from ansible_collections.community.clickhouse.plugins.modules.clickhouse_db import ClickHouseDB
+
+
+@pytest.fixture
+def mock_execute(mocker):
+    return mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.execute_query",
+        return_value=[]
+    )
+
+
+def _create_db(mocker, name="test_db", cluster=None, comment=None):
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+
+    return ClickHouseDB(
+        module=mock_module,
+        client=mock_client,
+        name=name,
+        cluster=cluster,
+        comment=comment
+    )
+
+
+@pytest.fixture
+def db_factory(mocker):
+    def _make(cluster=None, comment=None, name="test_db", version=None):
+        # Patch version before creating DB
+        version_to_use = version if version else {'year': 26, 'feature': 1}
+        mocker.patch(
+            "ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.get_server_version",
+            return_value=version_to_use
+        )
+        return _create_db(mocker, name=name, cluster=cluster, comment=comment)
+    return _make
+
+
+def get_executed_query(mock_execute):
+    return mock_execute.call_args[0][2]
+
+
+def test_plain_db_with_default_options(db_factory, mock_execute):
+    db = db_factory()
+    db.create(engine=None, comment=None)
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "CREATE DATABASE test_db"
+
+
+def test_plain_db_with_options(db_factory, mock_execute):
+    db = db_factory()
+    db.create(engine='Ordinary', comment='test comment')
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "CREATE DATABASE test_db ENGINE = Ordinary COMMENT 'test comment'"
+
+
+def test_altering_existing_database_comment(db_factory, mock_execute):
+    db = db_factory()
+    db.update(engine=None, comment='test comment2')
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "ALTER DATABASE test_db MODIFY COMMENT 'test comment2'"
+
+
+def test_renaming_database(db_factory, mock_execute):
+    db = db_factory()
+    db.rename(target='test_db2')
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "RENAME DATABASE test_db TO test_db2"
+
+
+def test_droping_database(db_factory, mock_execute):
+    db = db_factory()
+    db.drop()
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "DROP DATABASE test_db"
+
+
+def test_altering_database_comment_not_supported(db_factory, mocker):
+    # Patch old server version
+    db = db_factory(
+        version={'year': 25, 'feature': 3}
+    )
+
+    db.module.warn = mocker.MagicMock()
+    mock_execute = mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.execute_query"
+    )
+
+    db.update(engine=None, comment='test comment2')
+
+    db.module.warn.assert_called_once()
+    mock_execute.assert_not_called()


### PR DESCRIPTION
##### SUMMARY
Since 25.8 has been introduced ALTER DATABASE [...] MODIFY COMMENT. Enabling support for this. Server version is verified and for versions < 25.8 warning will be displayed and module ends without error.

Cover functionality with unit and integration tests.

Closes #189

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
clickhouse_db
