### PR TITLE
refactor: refactor user/role settings

### DIFF
--- a/changelogs/fragments/178-refactor-user-role-settings.yml
+++ b/changelogs/fragments/178-refactor-user-role-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Refactored user/role settings for better maintainability and improved idempotency. Since now settings option accepts both list(old) argument or dictionary(new). Profiles are moved to a separate option. (https://github.com/ansible-collections/community.clickhouse/pull/178).

--- a/changelogs/fragments/178-refactor-user-role-settings.yml
+++ b/changelogs/fragments/178-refactor-user-role-settings.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - Refactored user/role settings for better maintainability and improved idempotency. Since now settings option accepts both list(old) argument or dictionary(new). Profiles are moved to a separate option. (https://github.com/ansible-collections/community.clickhouse/pull/178).
+  - clickhouse_user - added the ``profile`` argument to apply settings profiles to user (https://github.com/ansible-collections/community.clickhouse/pull/196).
+  - clickhouse_role - added the ``profile`` argument to apply settings profiles to role (https://github.com/ansible-collections/community.clickhouse/pull/196).  

--- a/plugins/module_utils/entity_settings.py
+++ b/plugins/module_utils/entity_settings.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse import (
+    execute_query
+)
+
+
+class EntitySettings():
+    def __init__(self, module: AnsibleModule, client, entity_name: str, entity_type: str):
+        self.module = module
+        self.client = client
+        self.name = entity_name
+        self.entity_type = entity_type.lower()
+
+        if self.entity_type not in ("user", "role"):
+            self.module.fail_json(msg=f"entity_type must be 'user' or 'role', got {entity_type}")
+
+    def _get_where_column(self):
+        return "user_name" if self.entity_type == "user" else "role_name"
+
+    def fetch(self):
+        """Fetch current settings from system.settings_profile_elements."""
+        """Returns raw result."""
+        column = self._get_where_column()
+        query = (
+            "SELECT setting_name, value, min, max, writability, inherit_profile "
+            f"FROM system.settings_profile_elements "
+            f"WHERE {column} = '{self.name}'"
+        )
+
+        result = execute_query(self.module, self.client, query)
+        return result
+
+    def _normalize_current_settings(self, rows):
+        """Convert DB rows into easy-to-compare structures."""
+        current_settings = {}
+        current_profiles = []
+
+        for row in rows:
+            setting_name, value, min, max, writability, inherit_profile = row
+            if inherit_profile:
+                current_profiles.append(inherit_profile)
+            else:
+                current_settings[setting_name] = {}
+                current_settings[setting_name]['value'] = value
+                if min:
+                    current_settings[setting_name]['min'] = min
+                if max:
+                    current_settings[setting_name]['max'] = max
+                if writability:
+                    current_settings[setting_name]['writability'] = writability
+
+        return current_settings, sorted(current_profiles)
+
+    def compare_and_build_clause(self, desired_settings, desired_profiles):
+        # In case only one is passed
+        if not desired_settings:
+            desired_settings = {}
+        if not desired_profiles:
+            desired_profiles = []
+        current_rows = self.fetch()
+        current_settings, current_profiles = self._normalize_current_settings(current_rows)
+        desired_settings = self._normalize_settings(desired_settings)
+
+        # Compare
+        settings_changed = current_settings != desired_settings
+        profiles_changed = set(current_profiles) != set(desired_profiles)
+        changed = settings_changed or profiles_changed
+
+        if not changed:
+            return False, "", {}
+
+        parts = []
+
+        # PROFILE 'name'
+        for profile in desired_profiles:
+            parts.append(f"PROFILE '{profile}'")
+
+        # SETTINGS key='val' [MIN 'min_val'] [MAX 'max_val'] [WRITABLE|CONST|CHANGEABLE_IN_READONLY]
+        for key, setting in desired_settings.items():
+            prepared = f"{key}='{setting['value']}'"
+            if setting.get('min'):
+                prepared += f" MIN '{setting['min']}'"
+            if setting.get('max'):
+                prepared += f" MAX '{setting['max']}'"
+            if setting.get('writability'):
+                prepared += f" {setting['writability']}"
+            parts.append(f"{prepared}")
+
+        if desired_profiles or desired_settings:
+            clause = " SETTINGS " + ", ".join(parts) if parts else ""
+        else:
+            clause = " SETTINGS NONE"
+
+        # Simple diff for Ansible output
+        diff = {
+            "before": {"settings": current_settings, "profiles": current_profiles},
+            "after": {"settings": desired_settings, "profiles": desired_profiles}
+        }
+
+        return changed, clause, diff
+
+    def _normalize_settings(self, settings):
+        if not settings:
+            return {}
+        # Map with DB aliases
+        writability_map = {
+            'READONLY': 'CONST',
+            'CONST': 'CONST'
+        }
+        normalized = {}
+
+        for setting_name, setting_config in settings.items():
+            normalized_config = setting_config.copy()
+
+            # Convert numbers to strings (for all fields)
+            for prop_name, prop_value in normalized_config.items():
+                if isinstance(prop_value, (int, float)):
+                    normalized_config[prop_name] = str(prop_value)
+
+            # Writable uppercase and replace aliases
+            if normalized_config.get('writability', ''):
+                writability_value = normalized_config['writability'].upper()
+                normalized_config['writability'] = writability_map.get(
+                    writability_value,
+                    writability_value
+                )
+
+            normalized[setting_name] = normalized_config
+
+        return normalized

--- a/plugins/modules/clickhouse_role.py
+++ b/plugins/modules/clickhouse_role.py
@@ -28,6 +28,7 @@ author:
   - Don Naro (@oranod)
   - Aleksandr Vagachev (@aleksvagachev)
   - Andrew Klychkov (@Andersson007)
+  - Rafal Kozlowski (@rkozlo)
 
 extends_documentation_fragment:
   - community.clickhouse.client_inst_opts
@@ -78,8 +79,13 @@ EXAMPLES = r"""
     name: test_role
     state: present
     settings:
-      - max_memory_usage = 15000 MIN 15000 MAX 16000 READONLY
-      - PROFILE restricted
+      max_memory_usage:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: readonly
+    profiles:
+      - restricted
     cluster: test_cluster
 
 - name: Create a role with settings and profiles
@@ -87,11 +93,11 @@ EXAMPLES = r"""
     name: test_role
     state: present
     settings:
-        max_memory_usage:
-          value: 15000
-          min: 15000
-          max: 16000
-          writability: readonly
+      max_memory_usage:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: readonly
     profiles:
       - restricted
     cluster: test_cluster

--- a/plugins/modules/clickhouse_role.py
+++ b/plugins/modules/clickhouse_role.py
@@ -61,7 +61,7 @@ options:
     version_added: 2.2.0
     description:
       - Settings profiles that will be applied to role.
-      - Can be only used with O(settings) as C(dict)
+      - Can be only used with O(settings) as C(dict).
     type: list
     elements: str
     default: []

--- a/plugins/modules/clickhouse_role.py
+++ b/plugins/modules/clickhouse_role.py
@@ -54,9 +54,17 @@ options:
   settings:
     description:
       - Settings with their limitations that apply to the role.
-      - You can also specify the profile from which the settings will be inherited.
+      - Can pass either list(obsolete) or dictionary.
+      - You can also specify the profile from which the settings will be inherited C(list).
+    type: raw
+  profiles:
+    version_added: 2.2.0
+    description:
+      - Settings profiles that will be applied to role.
+      - Can be only used with O(settings) as C(dict)
     type: list
     elements: str
+    default: []
 """
 
 EXAMPLES = r"""
@@ -72,6 +80,20 @@ EXAMPLES = r"""
     settings:
       - max_memory_usage = 15000 MIN 15000 MAX 16000 READONLY
       - PROFILE restricted
+    cluster: test_cluster
+
+- name: Create a role with settings and profiles
+  community.clickhouse.clickhouse_role:
+    name: test_role
+    state: present
+    settings:
+        max_memory_usage:
+          value: 15000
+          min: 15000
+          max: 16000
+          writability: readonly
+    profiles:
+      - restricted
     cluster: test_cluster
 
 - name: Remove role
@@ -100,7 +122,7 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     execute_query,
     get_main_conn_kwargs,
 )
-
+from ansible_collections.community.clickhouse.plugins.module_utils.entity_settings import EntitySettings
 executed_statements = []
 
 
@@ -109,6 +131,7 @@ class ClickHouseRole:
         self.module = module
         self.client = client
         self.name = name
+        self.settings = EntitySettings(self.module, self.client, self.name, 'role')
         self.exists = self.check_exists()
 
     def check_exists(self):
@@ -220,13 +243,17 @@ class ClickHouseRole:
             if self.module.params['cluster']:
                 query += " ON CLUSTER %s" % self.module.params['cluster']
 
-            list_settings = self.module.params['settings']
-            if list_settings:
-                query += " SETTINGS"
-                for index, value in enumerate(list_settings):
-                    query += " %s" % value
-                    if index < len(list_settings) - 1:
-                        query += ","
+            if isinstance(self.module.params['settings'], list):
+                list_settings = self.module.params['settings']
+                if list_settings:
+                    query += " SETTINGS"
+                    for index, value in enumerate(list_settings):
+                        query += " %s" % value
+                        if index < len(list_settings) - 1:
+                            query += ","
+            elif isinstance(self.module.params['settings'], dict) or self.module.params['profiles']:
+                settings_entity = self.settings.compare_and_build_clause(self.module.params['settings'], self.module.params['profiles'])
+                query += settings_entity[1]
 
             executed_statements.append(query)
 
@@ -238,24 +265,30 @@ class ClickHouseRole:
         else:
             return False
 
-    def alter(self, settings):
+    def alter(self, settings, profiles, cluster):
         """Update role settings using ALTER ROLE"""
         if not self.exists:
             return False
 
         query = "ALTER ROLE %s" % self.name
 
-        if self.module.params['cluster']:
-            query += " ON CLUSTER %s" % self.module.params['cluster']
+        if cluster:
+            query += " ON CLUSTER %s" % cluster
 
-        # Handle settings updates
-        if settings is not None and len(settings) > 0:
-            # Set these settings
-            query += " SETTINGS"
-            for index, value in enumerate(settings):
-                query += " %s" % value
-                if index < len(settings) - 1:
-                    query += ","
+        if isinstance(settings, list):
+            # Handle settings updates
+            if settings is not None and len(settings) > 0:
+                # Set these settings
+                query += " SETTINGS"
+                for index, value in enumerate(settings):
+                    query += " %s" % value
+                    if index < len(settings) - 1:
+                        query += ","
+        elif isinstance(settings, dict) or (settings is None and profiles):
+            settings_entity = self.settings.compare_and_build_clause(settings, profiles)
+            if settings_entity[0] is False:
+                return False
+            query += settings_entity[1]
 
         executed_statements.append(query)
 
@@ -288,7 +321,8 @@ def main():
         state=dict(type="str", choices=["present", "absent"], default="present"),
         name=dict(type="str", required=True),
         cluster=dict(type='str', default=None),
-        settings=dict(type='list', elements='str'),
+        settings=dict(type='raw'),
+        profiles=dict(type='list', elements='str', default=[])
     )
 
     # Instantiate an object of module class
@@ -306,6 +340,9 @@ def main():
     main_conn_kwargs = get_main_conn_kwargs(module)
     state = module.params["state"]
     name = module.params["name"]
+    settings = module.params["settings"]
+    profiles = module.params["profiles"]
+    cluster = module.params["cluster"]
 
     # Will fail if no driver informing the user
     check_clickhouse_driver(module)
@@ -324,12 +361,16 @@ def main():
             changed = role.create()
         else:
             # Role exists, check if settings need to be updated
-            if desired_settings is not None and len(desired_settings) > 0:  # Only check settings if they are specified and not empty
-                current_definition = role.get_current_role_definition()
-                current_settings = role.parse_settings_from_create_statement(current_definition) if current_definition else []
+            if isinstance(desired_settings, list):
+                if desired_settings is not None and len(desired_settings) > 0:  # Only check settings if they are specified and not empty
+                    current_definition = role.get_current_role_definition()
+                    current_settings = role.parse_settings_from_create_statement(current_definition) if current_definition else []
 
-                if role.settings_changed(current_settings, desired_settings):
-                    changed = role.alter(desired_settings)
+                    if role.settings_changed(current_settings, desired_settings):
+                        changed = role.alter(desired_settings, profiles, cluster)
+            # No need to check settings in new settings parameter
+            elif isinstance(settings, dict) or profiles:
+                changed = role.alter(desired_settings, profiles, cluster)
     else:
         # If state is absent
         if role.exists:

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -27,6 +27,7 @@ attributes:
 author:
   - Aleksandr Vagachev (@aleksvagachev)
   - Andrew Klychkov (@Andersson007)
+  - Rafal Kozlowski (@rkozlo)
 
 extends_documentation_fragment:
   - community.clickhouse.client_inst_opts
@@ -257,8 +258,11 @@ EXAMPLES = r'''
     login_password: my_password
     name: test_user
     settings:
-      - max_memory_usage = 20000 READONLY
-      - max_threads = 8
+      max_memory_usage:
+        value: 20000
+        writability: readonly
+      max_threads:
+        value: 8
 
 - name: Update user settings (idempotent - only updates if different)
   community.clickhouse.clickhouse_user:
@@ -277,7 +281,7 @@ EXAMPLES = r'''
         value: 8
         writability: writable
 
-- name: Create user with specific settings
+- name: Create user with specific settings and profile
   community.clickhouse.clickhouse_user:
     login_host: localhost
     login_user: alice
@@ -289,8 +293,13 @@ EXAMPLES = r'''
       type: sha256_hash
     cluster: test_cluster
     settings:
-      - max_memory_usage = 15000 MIN 15000 MAX 16000 READONLY
-      - PROFILE 'restricted'
+      max_memory_usage:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: readonly
+    profiles:
+      - restricted
     state: present
 
 - name: Create a user that can only connect from a specified host

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -111,11 +111,12 @@ options:
   settings:
     description:
       - Settings with their constraints applied by default at user login.
-      - You can also specify the profile from which the settings will be inherited.
+      - Can pass either C(list)(obsolete) or dictionary.
+      - You can also specify the profile from which the settings will be inherited C(list).
       - When specified for an existing user, settings will only be updated if they differ from current settings.
       - The module fetches current settings from C(system.settings_profile_elements) for comparison.
-    type: list
-    elements: str
+      - If no O(profiles) or O(settings) defined setting will not remove anything. Set to {} to purge it.
+    type: raw
     version_added: '0.5.0'
   roles:
     description:
@@ -181,6 +182,14 @@ options:
         elements: str
         required: false
     version_added: '1.0.0'
+  profiles:
+    version_added: 2.2.0
+    description:
+      - Settings profiles that will be applied to role.
+      - Can be only used with O(settings) as C(dict)
+    type: list
+    elements: str
+    default: []
 '''
 
 EXAMPLES = r'''
@@ -250,6 +259,23 @@ EXAMPLES = r'''
     settings:
       - max_memory_usage = 20000 READONLY
       - max_threads = 8
+
+- name: Update user settings (idempotent - only updates if different)
+  community.clickhouse.clickhouse_user:
+    login_host: localhost
+    login_user: alice
+    login_db: foo
+    login_password: my_password
+    name: test_user
+    settings:
+      max_memory_usage:
+        value: 20G
+        min: 10G
+        max: 25G
+        writability: readonly
+      max_threads:
+        value: 8
+        writability: writable
 
 - name: Create user with specific settings
   community.clickhouse.clickhouse_user:
@@ -342,6 +368,7 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     execute_query,
     get_main_conn_kwargs,
 )
+from ansible_collections.community.clickhouse.plugins.module_utils.entity_settings import EntitySettings
 
 PRIV_ERR_CODE = 497
 executed_statements = []
@@ -359,6 +386,8 @@ class ClickHouseUser():
         self.current_roles = []
         self.current_settings = {}
         self.current_user_hosts = {}
+        self.settings = EntitySettings(self.module, self.client, self.name, 'user')
+
         # Fetch actual values from DB and
         # update the attributes with them
         self.__populate_info()
@@ -447,7 +476,7 @@ class ClickHouseUser():
         return user_hosts_dict
 
     def create(self, type_password, password, cluster, user_hosts, settings,
-               roles, roles_mode, default_roles, default_roles_mode, authentication):
+               roles, roles_mode, default_roles, default_roles_mode, authentication, profiles):
 
         query = "CREATE USER '%s'" % self.name
 
@@ -464,12 +493,18 @@ class ClickHouseUser():
         if cluster:
             query += " ON CLUSTER %s" % cluster
 
-        if settings:
-            query += " SETTINGS"
-            for index, value in enumerate(settings):
-                query += " %s" % value
-                if index < len(settings) - 1:
-                    query += ","
+        if settings or profiles:
+            if isinstance(settings, list):
+                query += " SETTINGS"
+                for index, value in enumerate(settings):
+                    query += " %s" % value
+                    if index < len(settings) - 1:
+                        query += ","
+            elif isinstance(settings, dict):
+                settings_entity = self.settings.compare_and_build_clause(settings, profiles)
+                query += settings_entity[1]
+            else:
+                self.module.fail_json(msg=f"Unexpexted settings passed: {settings}. Supported list or dict.")
 
         executed_statements.append(query)
 
@@ -485,7 +520,7 @@ class ClickHouseUser():
         return True
 
     def update(self, update_password, type_password, password, cluster, user_hosts,
-               roles, roles_mode, default_roles, default_roles_mode, settings, authentication):
+               roles, roles_mode, default_roles, default_roles_mode, settings, authentication, profiles):
 
         if roles is not None:
             self.__update_roles(roles, roles_mode, cluster)
@@ -498,8 +533,8 @@ class ClickHouseUser():
         if user_hosts is not None:
             self.__update_host(user_hosts, cluster)
 
-        if settings is not None:
-            self.__update_settings(settings, cluster)
+        if settings is not None or profiles is not None:
+            self.__update_settings(settings, cluster, profiles)
 
         return self.changed
 
@@ -701,63 +736,74 @@ class ClickHouseUser():
 
         self.changed = True
 
-    def __update_settings(self, settings, cluster):
+    def __update_settings(self, settings, cluster, profiles):
         """Update user settings idempotently by comparing with current settings"""
-        # Parse desired settings into a comparable format
-        desired_settings = {}
-        desired_profiles = []
 
-        for setting in settings:
-            setting_upper = setting.upper()
-            # Handle PROFILE separately as it's not a regular setting
-            if 'PROFILE' in setting_upper:
-                # Extract profile name (handle both PROFILE 'name' and PROFILE name)
-                profile_part = setting.split(None, 1)[1].strip().strip("'\"")
-                desired_profiles.append(profile_part)
-            else:
-                # Extract setting name (first word before = or space)
-                setting_name = setting.split()[0].split('=')[0].strip()
-                # Normalize the setting string for comparison
-                normalized = ' '.join(setting.split())
-                desired_settings[setting_name] = normalized
+        if isinstance(settings, list):
+            # Parse desired settings into a comparable format
+            desired_settings = {}
+            desired_profiles = []
 
-        # Compare current with desired
-        needs_update = False
+            for setting in settings:
+                setting_upper = setting.upper()
+                # Handle PROFILE separately as it's not a regular setting
+                if 'PROFILE' in setting_upper:
+                    # Extract profile name (handle both PROFILE 'name' and PROFILE name)
+                    profile_part = setting.split(None, 1)[1].strip().strip("'\"")
+                    desired_profiles.append(profile_part)
+                else:
+                    # Extract setting name (first word before = or space)
+                    setting_name = setting.split()[0].split('=')[0].strip()
+                    # Normalize the setting string for comparison
+                    normalized = ' '.join(setting.split())
+                    desired_settings[setting_name] = normalized
 
-        # Check if any setting values differ
-        for setting_name, desired_def in desired_settings.items():
-            current_def = self.current_settings.get(setting_name, '')
-            # Normalize both for comparison (case-insensitive, whitespace-normalized)
-            current_normalized = ' '.join(current_def.upper().split())
-            desired_normalized = ' '.join(desired_def.upper().split())
+            # Compare current with desired
+            needs_update = False
 
-            if current_normalized != desired_normalized:
-                needs_update = True
-                break
+            # Check if any setting values differ
+            for setting_name, desired_def in desired_settings.items():
+                current_def = self.current_settings.get(setting_name, '')
+                # Normalize both for comparison (case-insensitive, whitespace-normalized)
+                current_normalized = ' '.join(current_def.upper().split())
+                desired_normalized = ' '.join(desired_def.upper().split())
 
-        # Check if there are settings to remove (current has settings not in desired)
-        if not needs_update:
-            for setting_name in self.current_settings:
-                if setting_name not in desired_settings:
-                    # There's a setting currently applied that's not in desired
-                    # We need to reapply to remove it
+                if current_normalized != desired_normalized:
                     needs_update = True
                     break
 
-        # Only update if settings actually differ
-        if not needs_update:
+            # Check if there are settings to remove (current has settings not in desired)
+            if not needs_update:
+                for setting_name in self.current_settings:
+                    if setting_name not in desired_settings:
+                        # There's a setting currently applied that's not in desired
+                        # We need to reapply to remove it
+                        needs_update = True
+                        break
+
+            # Only update if settings actually differ
+            if not needs_update:
+                return
+
+            # Build the ALTER USER query
+            query = "ALTER USER '%s' SETTINGS" % self.name
+            for index, value in enumerate(settings):
+                query += " %s" % value
+                if index < len(settings) - 1:
+                    query += ","
+
+            if cluster:
+                query += " ON CLUSTER %s" % cluster
+        elif isinstance(settings, dict) or profiles:
+            query = "ALTER USER '%s'" % self.name
+            changed, settings_entity, changes = self.settings.compare_and_build_clause(settings, profiles)
+            if not changed:
+                return
+            query += settings_entity
+            if cluster:
+                query += " ON CLUSTER %s" % cluster
+        else:
             return
-
-        # Build the ALTER USER query
-        query = "ALTER USER '%s' SETTINGS" % self.name
-        for index, value in enumerate(settings):
-            query += " %s" % value
-            if index < len(settings) - 1:
-                query += ","
-
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
-
         executed_statements.append(query)
 
         if not self.module.check_mode:
@@ -837,13 +883,14 @@ def main():
             default='on_create', no_log=False
         ),
         user_hosts=dict(type='list', elements='dict'),
-        settings=dict(type='list', elements='str'),
+        settings=dict(type='raw'),
+        profiles=dict(type='list', elements='str', default=[]),
         roles=dict(type='list', elements='str', default=None),
         default_roles=dict(type='list', elements='str', default=None),
         roles_mode=dict(type='str', choices=['listed_only', 'append', 'remove'],
                         default='listed_only'),
         default_roles_mode=dict(type='str', choices=['listed_only', 'append', 'remove'],
-                                default='listed_only'),
+                                default='listed_only')
     )
 
     # Instantiate an object of module class
@@ -868,6 +915,7 @@ def main():
     update_password = module.params['update_password']
     user_hosts = module.params['user_hosts']
     settings = module.params['settings']
+    profiles = module.params['profiles']
     roles = module.params['roles']
     roles_mode = module.params['roles_mode']
     default_roles = module.params['default_roles']
@@ -887,11 +935,11 @@ def main():
     if state == 'present':
         if not user.user_exists:
             changed = user.create(type_password, password, cluster, user_hosts, settings,
-                                  roles, roles_mode, default_roles, default_roles_mode, authentication)
+                                  roles, roles_mode, default_roles, default_roles_mode, authentication, profiles)
         else:
             # If user exists
             changed = user.update(update_password, type_password, password, cluster, user_hosts,
-                                  roles, roles_mode, default_roles, default_roles_mode, settings, authentication)
+                                  roles, roles_mode, default_roles, default_roles_mode, settings, authentication, profiles)
     else:
         # If state is absent
         if user.user_exists:

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -186,7 +186,7 @@ options:
     version_added: 2.2.0
     description:
       - Settings profiles that will be applied to role.
-      - Can be only used with O(settings) as C(dict)
+      - Can be only used with O(settings) as C(dict).
     type: list
     elements: str
     default: []

--- a/tests/integration/targets/clickhouse_role/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_role/tasks/initial.yml
@@ -267,3 +267,170 @@
     that:
     - result is not changed
     - result.executed_statements == []
+
+# Test 12 - Create role with new settings field
+- name: Test 12 - Create role with settings as dictionary in real mode
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    settings:
+      max_memory_usage:
+        value: 15000
+        writability: readonly
+      max_memory_usage_for_all_queries:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: writable
+
+- name: Test 12 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["CREATE ROLE test_role SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
+
+- name: Test 12 - Check the role was created
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT 1 FROM system.roles WHERE name = 'test_role'"
+
+- name: Test 12 - Verify that the role is present
+  ansible.builtin.assert:
+    that:
+    - result.result == [[1]]
+
+- name: Test 12 - Create role with settings as dictionary in real mode - idempotency
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    settings:
+      max_memory_usage:
+        value: 15000
+        writability: readonly
+      max_memory_usage_for_all_queries:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: writable
+
+- name: Test 12 - Drop test_role
+  community.clickhouse.clickhouse_role:
+    state: absent
+    name: test_role
+
+# Test 13 - create role with passing profiles 
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Test 13 - Create settings profiles for later tests
+  community.clickhouse.clickhouse_client:
+    execute: "{{ __query }}"
+  loop:
+    - CREATE SETTINGS PROFILE web
+    - CREATE SETTINGS PROFILE app
+  loop_control:
+    loop_var: __query
+
+- name: Test 13 - Create role with profiles in real mode
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    profiles:
+      - web
+      - app
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["CREATE ROLE test_role SETTINGS PROFILE 'web', PROFILE 'app'"]
+
+- name: Test 13 - Check the role was created
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT 1 FROM system.roles WHERE name = 'test_role'"
+
+- name: Test 13 - Verify that the role is present
+  ansible.builtin.assert:
+    that:
+    - result.result == [[1]]
+
+- name: Test 13 - Create role with settings as dictionary in real mode - idempotency
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    profiles:
+      - web
+      - app
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Test 13 - Alter role with settings as dictionary in real mode
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    profiles:
+      - web
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER ROLE test_role SETTINGS PROFILE 'web'"]
+
+- name: Test 13 - Alter role removing settings with settings as dictionary - workaround 
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    settings: {}
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER ROLE test_role SETTINGS NONE"]
+
+- name: Test 13 - Alter role removing settings with settings as dictionary - idempotency
+  register: result
+  community.clickhouse.clickhouse_role:
+    state: present
+    name: test_role
+    settings: {}
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Test 13 - Drop test_role
+  community.clickhouse.clickhouse_role:
+    state: absent
+    name: test_role
+
+- name: Test 13 - Drop test_role
+  community.clickhouse.clickhouse_role:
+    state: absent
+    name: test_role
+
+- name: Test 13 - Drop test settings profiles
+  community.clickhouse.clickhouse_client:
+    execute: "{{ __query }}"
+  loop:
+    - DROP SETTINGS PROFILE 'web'
+    - DROP SETTINGS PROFILE 'app'
+  loop_control:
+    loop_var: __query

--- a/tests/integration/targets/clickhouse_user/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_user/tasks/initial.yml
@@ -2140,3 +2140,119 @@
   community.clickhouse.clickhouse_user:
     state: absent
     name: test_user
+
+- name: Create user with settings as dictionary in real mode
+  register: result
+  community.clickhouse.clickhouse_user:
+    state: present
+    name: test_user
+    settings:
+      max_memory_usage:
+        value: 15000
+        writability: readonly
+      max_memory_usage_for_all_queries:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: writable
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["CREATE USER 'test_user' SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
+
+- name: Check user has settings
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT setting_name FROM system.settings_profile_elements WHERE user_name = 'test_user'"
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+      - result.result[0][0] == "max_memory_usage"
+      - result.result[1][0] == "max_memory_usage_for_all_queries"
+
+- name: Create user with settings as dictionary in real mode - idempotency
+  register: result
+  community.clickhouse.clickhouse_user:
+    state: present
+    name: test_user
+    settings:
+      max_memory_usage:
+        value: 15000
+        writability: readonly
+      max_memory_usage_for_all_queries:
+        value: 15000
+        min: 15000
+        max: 16000
+        writability: writable
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+  
+- name: Test 13 - Create settings profiles for later tests
+  community.clickhouse.clickhouse_client:
+    execute: "{{ __query }}"
+  loop:
+    - CREATE SETTINGS PROFILE web
+    - CREATE SETTINGS PROFILE app
+  loop_control:
+    loop_var: __query
+
+- name: Alter user with settings as dictionary in real mode
+  register: result
+  community.clickhouse.clickhouse_user:
+    state: present
+    name: test_user
+    profiles:
+      - web
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER USER 'test_user' SETTINGS PROFILE 'web'"]
+
+- name: Alter user removing settings with settings as dictionary - workaround 
+  register: result
+  community.clickhouse.clickhouse_user:
+    state: present
+    name: test_user
+    settings: {}
+
+- name: Test 13 - Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER USER 'test_user' SETTINGS NONE"]
+
+- name: Alter user removing settings with settings as dictionary - idempotency
+  register: result
+  community.clickhouse.clickhouse_user:
+    state: present
+    name: test_user
+    settings: {}
+
+- name:  Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Drop test_user
+  community.clickhouse.clickhouse_role:
+    state: absent
+    name: test_role
+
+- name:  Drop test settings profiles
+  community.clickhouse.clickhouse_client:
+    execute: "{{ __query }}"
+  loop:
+    - DROP SETTINGS PROFILE 'web'
+    - DROP SETTINGS PROFILE 'app'
+  loop_control:
+    loop_var: __query

--- a/tests/unit/plugins/module_utils/test_entity_settings.py
+++ b/tests/unit/plugins/module_utils/test_entity_settings.py
@@ -1,0 +1,445 @@
+from __future__ import absolute_import, division, print_function
+import pytest
+from ansible_collections.community.clickhouse.plugins.module_utils.entity_settings import EntitySettings
+
+
+@pytest.fixture
+def user_ent(mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query",
+        return_value=[
+            ('max_memory_usage', '15000', '15000', '16000', 'CONST', None)
+        ]
+    )
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+    return EntitySettings(module=mock_module, client=mock_client, entity_name="test_user", entity_type="user")
+
+
+@pytest.fixture
+def role_ent(mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query",
+        return_value=[
+            ('max_memory_usage', '15000', '15000', '16000', 'CONST', None)
+        ]
+    )
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+    return EntitySettings(module=mock_module, client=mock_client, entity_name="test_role", entity_type="role")
+
+
+def test_where_clause_for_user(user_ent):
+    result = user_ent._get_where_column()
+    assert result == "user_name"
+
+
+def test_where_clause_for_role(role_ent):
+    result = role_ent._get_where_column()
+    assert result == "role_name"
+
+
+def test_result_for_fetching_current_setings(user_ent):
+    result = user_ent.fetch()
+    assert result == [('max_memory_usage', '15000', '15000', '16000', 'CONST', None)]
+
+
+def test_normalizing_current_settings_one_setting_no_profile(role_ent):
+    result_settings, result_profiles = role_ent._normalize_current_settings(role_ent.fetch())
+
+    assert result_settings == {'max_memory_usage': {'value': '15000', 'min': '15000', 'max': '16000', 'writability': 'CONST'}}
+    assert result_profiles == []
+
+
+def test_normalizing_current_settings_no_setting_one_profile(role_ent, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query",
+        return_value=[(None, None, None, None, None, 'web')]
+    )
+    result_settings, result_profiles = role_ent._normalize_current_settings(role_ent.fetch())
+
+    assert result_settings == {}
+    assert result_profiles == ['web']
+
+
+def test_normalizing_current_settings_one_setting_one_profile(role_ent, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query",
+        return_value=[
+            (None, None, None, None, None, 'test_profile'),
+            ('max_memory_usage', '15000', '15000', '16000', None, None)
+        ]
+    )
+    result_settings, result_profiles = role_ent._normalize_current_settings(role_ent.fetch())
+
+    assert result_settings == {'max_memory_usage': {'value': '15000', 'min': '15000', 'max': '16000'}}
+    assert result_profiles == ['test_profile']
+
+
+def test_normalizing_current_settings_many_setting_many_profile(role_ent, mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query", return_value=[
+        (None, None, None, None, None, 'test_profile'),
+        (None, None, None, None, None, 'app'),
+        (None, None, None, None, None, 'web'),
+        (None, None, None, None, None, 'web2'),
+        ('max_memory_usage', '15000', '15000', '16000', 'CONST', None),
+        ('allow_experimental_analyzer', '0', None, None, None, None),
+        ('allow_experimental_variant_type', '1', None, None, None, None)]
+    )
+    result_settings, result_profiles = role_ent._normalize_current_settings(role_ent.fetch())
+
+    assert result_settings == {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'CONST'
+        },
+        'allow_experimental_variant_type': {
+            'value': '1'
+        },
+        'allow_experimental_analyzer': {
+            'value': '0'
+        }
+    }
+    assert result_profiles == sorted(['test_profile', 'web', 'web2', 'app'])
+
+
+def test_normalizing_passed_settings_none(user_ent):
+    settings = None
+    result = user_ent._normalize_settings(settings)
+    assert result == {}
+
+
+def test_normalizing_passed_settings_empty(user_ent):
+    settings = {}
+    result = user_ent._normalize_settings(settings)
+    assert result == {}
+
+
+def test_normalizing_passed_settings_lower_string(user_ent):
+    settings = {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'const'
+        }
+    }
+    result = user_ent._normalize_settings(settings)
+    assert result == {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'CONST'
+        }
+    }
+
+
+def test_normalizing_passed_settings_lower_alias(user_ent):
+    settings = {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'readonly'
+        }
+    }
+    result = user_ent._normalize_settings(settings)
+    assert result == {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'CONST'
+        }
+    }
+
+
+def test_normalizing_passed_settings_many_settings(user_ent):
+    settings = {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'readonly'
+        },
+        'allow_experimental_analyzer': {
+            'value': '0',
+            'min': None,
+            'max': None,
+            'writability': None
+        },
+        'session_timezone': {
+            'value': 'Asia/Novosibirsk',
+            'min': None,
+            'max': None,
+            'writability': 'changeable_in_readonly'
+        }
+    }
+    result = user_ent._normalize_settings(settings)
+    assert result == {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'CONST'
+        },
+        'allow_experimental_analyzer': {
+            'value': '0',
+            'min': None,
+            'max': None,
+            'writability': None
+        },
+        'session_timezone': {
+            'value': 'Asia/Novosibirsk',
+            'min': None,
+            'max': None,
+            'writability': 'CHANGEABLE_IN_READONLY'
+        }
+    }
+
+
+def test_normalizing_passed_settings_quota_numbers(user_ent):
+    result = user_ent._normalize_settings(
+        {
+            'max_memory_usage': {
+                'value': 15000,
+                'min': 15000,
+                'max': 16000,
+                'writability': 'CONST'
+            }
+        }
+    )
+    assert result == {
+        'max_memory_usage': {
+            'value': '15000',
+            'min': '15000',
+            'max': '16000',
+            'writability': 'CONST'
+        }
+    }
+
+
+def test_normalizing_passed_settings_quota_floats(user_ent):
+    result = user_ent._normalize_settings(
+        {
+            'async_insert_busy_timeout_increase_rate': {
+                'value': 0.2,
+                'min': 0.1,
+                'max': 0.5,
+                'writability': 'CONST'
+            }
+        }
+    )
+    assert result == {
+        'async_insert_busy_timeout_increase_rate': {
+            'value': '0.2',
+            'min': '0.1',
+            'max': '0.5',
+            'writability': 'CONST'
+        }
+    }
+
+
+def test_returning_entity_no_changes(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {
+            'max_memory_usage': {
+                'value': '15000',
+                'min': '15000',
+                'max': '16000',
+                'writability': 'CONST'
+            }
+        },
+        []
+    )
+    assert result == (False, '', {})
+
+
+def test_returning_entity_writability_changed(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {
+            'max_memory_usage': {
+                'value': '15000',
+                'min': '15000',
+                'max': '16000',
+                'writability': 'WRITABLE'
+            }
+        },
+        []
+    )
+    assert result[0] is True
+    assert result[1] == " SETTINGS max_memory_usage='15000' MIN '15000' MAX '16000' WRITABLE"
+    assert result[2] == {
+        'before': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'CONST'
+                }
+            },
+            'profiles': []
+        },
+        'after': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'WRITABLE'
+                }
+            },
+            'profiles': []
+        }
+    }
+
+
+def test_returning_entity_new_profile_appear(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {
+            'max_memory_usage': {
+                'value': '15000',
+                'min': '15000',
+                'max': '16000',
+                'writability': 'WRITABLE'
+            }
+        },
+        ['web']
+    )
+    assert result[0] is True
+    assert result[1] == " SETTINGS PROFILE 'web', max_memory_usage='15000' MIN '15000' MAX '16000' WRITABLE"
+    assert result[2] == {
+        'before': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'CONST'
+                }
+            },
+            'profiles': []
+        },
+        'after': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'WRITABLE'
+                }
+            },
+            'profiles': ['web']
+        }
+    }
+
+
+def test_returning_entity_new_setting_appear(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {
+            'max_memory_usage': {
+                'value': '15000',
+                'min': '15000',
+                'max': '16000',
+                'writability': 'WRITABLE'
+            },
+            'allow_experimental_analyzer': {
+                'value': '0',
+                'min': None,
+                'max': None,
+                'writability': None
+            }
+
+        },
+        []
+    )
+    assert result[0] is True
+    assert result[1] == " SETTINGS max_memory_usage='15000' MIN '15000' MAX '16000' WRITABLE, allow_experimental_analyzer='0'"
+    assert result[2] == {
+        'before': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'CONST'
+                }
+            },
+            'profiles': []
+        },
+        'after': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'WRITABLE'
+                },
+                'allow_experimental_analyzer': {
+                    'value': '0',
+                    'min': None,
+                    'max': None,
+                    'writability': None
+                }
+            },
+            'profiles': []
+        }
+    }
+
+
+def test_returning_entity_purge_settings(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {},
+        []
+    )
+    assert result[0] is True
+    assert result[1] == " SETTINGS NONE"
+    assert result[2] == {
+        'before': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'CONST'
+                }
+            },
+            'profiles': []
+        },
+        'after': {
+            'settings': {},
+            'profiles': []
+        }
+    }
+
+
+def test_returning_entity_set_only_profiles(user_ent):
+    result = user_ent.compare_and_build_clause(
+        {},
+        ['web', 'app', 'front']
+    )
+    assert result[0] is True
+    assert result[1] == " SETTINGS PROFILE 'web', PROFILE 'app', PROFILE 'front'"
+    assert result[2] == {
+        'before': {
+            'settings': {
+                'max_memory_usage': {
+                    'value': '15000',
+                    'min': '15000',
+                    'max': '16000',
+                    'writability': 'CONST'
+                }
+            },
+            'profiles': []
+        },
+        'after': {
+            'settings': {},
+            'profiles': ['web', 'app', 'front']
+        }
+    }

--- a/tests/unit/plugins/modules/test_clickhouse_role.py
+++ b/tests/unit/plugins/modules/test_clickhouse_role.py
@@ -1,0 +1,98 @@
+from __future__ import absolute_import, division, print_function
+import pytest
+from ansible_collections.community.clickhouse.plugins.modules.clickhouse_role import ClickHouseRole
+
+
+@pytest.fixture
+def role(mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.modules.clickhouse_role.execute_query"
+                 , return_value=[(1)])
+
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+
+    return ClickHouseRole(module=mock_module, client=mock_client, name="test_role")
+
+
+@pytest.fixture
+def mock_execute(mocker):
+    return mocker.patch("ansible_collections.community.clickhouse.plugins.modules.clickhouse_role.execute_query", return_value=[])
+
+
+def get_executed_query(mock_execute):
+    return mock_execute.call_args[0][2]
+
+
+def test_alter_role_no_changes_new_setting(role, mock_execute, mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query"
+                 , return_value=[])
+    changed = role.alter({}, [], None)
+    assert changed is False
+    assert mock_execute.call_count == 0
+
+
+def test_alter_role_one_setting_old_setting(role, mock_execute):
+    changed = role.alter(["max_memory_usage='10G'"], [], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"
+
+
+def test_alter_role_one_setting_new_setting(role, mock_execute, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query",
+        return_value=[]
+    )
+    changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"
+
+
+def test_alter_role_one_profile_new_setting(role, mock_execute):
+    changed = role.alter({}, ['web'], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web'"
+
+
+def test_alter_role_one_profile_one_setting_new_setting(role, mock_execute):
+    changed = role.alter({'max_memory_usage': {'value': '10G'}}, ['web'], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web', max_memory_usage='10G'"
+
+
+def test_drop(role, mock_execute):
+    changed = role.drop()
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "DROP ROLE test_role"
+
+
+def test_alter_role_none_settings_nor_profile(role, mock_execute, mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query"
+                 , return_value=[('max_memory_usage', '10G', None, None, 'WRITABLE', False)])
+    changed = role.alter({}, [], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS NONE"
+
+
+def test_alter_role_del_settings_add_profile(role, mock_execute, mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query"
+                 , return_value=[('max_memory_usage', '10G', None, None, 'WRITABLE', False)])
+    changed = role.alter({}, ['web'], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web'"
+
+
+def test_alter_role_add_settings_del_profile(role, mock_execute, mocker):
+    mocker.patch("ansible_collections.community.clickhouse.plugins.module_utils.entity_settings.execute_query"
+                 , return_value=[('max_memory_usage', '10G', None, None, 'WRITABLE', 'web')])
+    changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"

--- a/tests/unit/plugins/modules/test_clickhouse_user.py
+++ b/tests/unit/plugins/modules/test_clickhouse_user.py
@@ -15,6 +15,24 @@ def user(mocker):
 
 
 @pytest.fixture
+def user_exist(mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_user.execute_query",
+        side_effect=[
+            [('alice', 'local_directory', ['sha256_hash'], [])],
+            [],
+            [],
+            [([], [], [], [])]
+        ])
+
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+
+    return ClickHouseUser(module=mock_module, client=mock_client, name="alice")
+
+
+@pytest.fixture
 def mock_execute(mocker):
     return mocker.patch("ansible_collections.community.clickhouse.plugins.modules.clickhouse_user.execute_query", return_value=[])
 
@@ -31,7 +49,7 @@ def test_create_ldap_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'ldap', 'server': 'ad'})
+        {'type': 'ldap', 'server': 'ad'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH ldap SERVER 'ad'"
 
@@ -40,7 +58,7 @@ def test_create_ldap_user_without_server(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'ldap'})
+        {'type': 'ldap'}, [])
     user.module.fail_json.assert_called_once()
 
 
@@ -48,7 +66,7 @@ def test_create_sha256_pass_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'sha256_password', 'password': 'password1'})
+        {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1'"
 
@@ -57,7 +75,9 @@ def test_create_sha256_hash_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'sha256_hash', 'password': '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'})
+        {'type': 'sha256_hash', 'password': '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'},
+        []
+    )
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_hash BY '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'"
 
@@ -65,7 +85,8 @@ def test_create_sha256_hash_user(user, mock_execute):
 def test_create_sha256_hash_user_old_way(user, mock_execute):
     user.create(
         'sha256_hash', '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e',
-        None, [], None, None, 'listed_only', None, 'listed_only', None)
+        None, [], None, None, 'listed_only',
+        None, 'listed_only', None, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_hash BY '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'"
 
@@ -73,7 +94,8 @@ def test_create_sha256_hash_user_old_way(user, mock_execute):
 def test_create_sha256_pass_user_old_way(user, mock_execute):
     user.create(
         'sha256_password', 'password1',
-        None, None, None, None, 'listed_only', None, 'listed_only', None)
+        None, None, None, None,
+        'listed_only', None, 'listed_only', None, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1'"
 
@@ -82,7 +104,7 @@ def test_create_not_identified_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'not_identified'})
+        {'type': 'not_identified'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' NOT IDENTIFIED"
 
@@ -91,7 +113,7 @@ def test_create_no_password_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'no_password'})
+        {'type': 'no_password'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH NO_PASSWORD"
 
@@ -101,7 +123,7 @@ def test_create_user_with_settings(user, mock_execute):
         None, None, None, None,
         ["max_concurrent_queries=3", "max_threads=8"],
         None, 'listed_only', None, 'listed_only',
-        {'type': 'sha256_password', 'password': 'password1'})
+        {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' SETTINGS max_concurrent_queries=3, max_threads=8"
 
@@ -112,7 +134,7 @@ def test_create_user_with_host_name_passed(user, mock_execute):
         [{'type': 'NAME', 'hosts': ['host1']}],
         None, None, 'listed_only',
         None, 'listed_only',
-        {'type': 'sha256_password', 'password': 'password1'})
+        {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST NAME 'host1'"
 
@@ -123,7 +145,7 @@ def test_create_user_with_host_ip_passed(user, mock_execute):
         [{'type': 'IP', 'hosts': ['127.0.0.1']}],
         None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'sha256_password', 'password': 'password1'})
+        {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '127.0.0.1'"
 
@@ -134,7 +156,7 @@ def test_create_user_with_host_cidr_passed(user, mock_execute):
         [{'type': 'IP', 'hosts': ['10.0.0.0/8']}],
         None, None,
         'listed_only', None,
-        'listed_only', {'type': 'sha256_password', 'password': 'password1'})
+        'listed_only', {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '10.0.0.0/8'"
 
@@ -145,6 +167,124 @@ def test_create_user_with_host_complex_passed(user, mock_execute):
         [{'type': 'IP', 'hosts': ['10.0.0.0/8']}, {'type': 'NAME', 'hosts': ['host1']}],
         None, None,
         'listed_only', None, 'listed_only',
-        {'type': 'sha256_password', 'password': 'password1'})
+        {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
     assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '10.0.0.0/8' HOST NAME 'host1'"
+
+
+def test_create_user_using_dict_settings(user, mock_execute):
+    user.create(
+        None, None, None, None,
+        {'max_memory_usage': {'value': '10G'}}, None,
+        'listed_only', None, 'listed_only',
+        None, [])
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "CREATE USER 'alice' SETTINGS max_memory_usage='10G'"
+
+
+def test_create_user_using_profiles_prameter(user, mock_execute):
+    user.create(
+        None, None, None, None,
+        {}, None,
+        'listed_only', None, 'listed_only',
+        None, ['app', 'web'])
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "CREATE USER 'alice' SETTINGS PROFILE 'app', PROFILE 'web'"
+
+
+def test_create_user_using_profiles_parameter_and_settings(user, mock_execute):
+    user.create(
+        None, None, None, None,
+        {'max_memory_usage': {'value': '10G'}}, None,
+        'listed_only', None, 'listed_only',
+        None, ['app', 'web'])
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == "CREATE USER 'alice' SETTINGS PROFILE 'app', PROFILE 'web', max_memory_usage='10G'"
+
+
+def test_create_user_using_profiles_parameter_and_settings_complex(user, mock_execute):
+    user.create(
+        None, None, None, None,
+        {
+            'max_memory_usage': {'value': '10G', 'max': '100G', 'min': '1G', 'writability': 'const'},
+            'allow_experimental_variant_type': {'value': '1', 'min': None, 'max': None, 'writability': 'WRITABLE'}
+        }, None,
+        'listed_only', None, 'listed_only',
+        None, ['app', 'web', 'test_profile', 'web2']
+    )
+    actual_query = get_executed_query(mock_execute)
+    assert actual_query == (
+        "CREATE USER 'alice' SETTINGS PROFILE 'app', "
+        "PROFILE 'web', PROFILE 'test_profile', "
+        "PROFILE 'web2', "
+        "max_memory_usage='10G' MIN '1G' MAX '100G' CONST, "
+        "allow_experimental_variant_type='1' WRITABLE")
+
+
+def test_alter_user_nothing_changed(user_exist, mock_execute):
+    changed = user_exist.update(
+        'on_create', None, None, None, [],
+        None, 'listed_only', None, 'listed_only',
+        {},
+        {'type': 'sha256_password'}, []
+    )
+    assert changed is False
+    assert mock_execute.call_count == 0
+    # assert mock_execute.assert_not_called()
+
+
+def test_alter_user_profile_added(user_exist, mock_execute):
+    changed = user_exist.update(
+        'on_create', None, None, None, [],
+        [], 'listed_only', None, 'listed_only',
+        {},
+        {'type': 'sha256_password'}, ['web']
+    )
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER USER 'alice' SETTINGS PROFILE 'web'"
+
+
+def test_alter_user_setting_added(user_exist, mock_execute):
+    changed = user_exist.update(
+        'on_create', None, None, None, [],
+        [], 'listed_only', None, 'listed_only',
+        {'max_memory_usage': {'value': '10G', 'min': '1G', 'max': '100G', 'writability': 'const'}},
+        {'type': 'sha256_password'}, []
+    )
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == (
+        "ALTER USER 'alice' SETTINGS "
+        "max_memory_usage='10G' MIN '1G' MAX '100G' CONST")
+
+
+def test_alter_user_old_setting_added(user_exist, mock_execute):
+    changed = user_exist.update(
+        'on_create', None, None, None, [],
+        [], 'listed_only', None, 'listed_only',
+        ["max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST"],
+        {'type': 'sha256_password'}, []
+    )
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER USER 'alice' SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST"
+
+
+def test_alter_user_old_setting_with_profile_added(user_exist, mock_execute):
+    changed = user_exist.update(
+        'on_create', None, None, None, [],
+        [], 'listed_only', None, 'listed_only',
+        ["max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST", "PROFILE web"],
+        {'type': 'sha256_password'}, []
+    )
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "ALTER USER 'alice' SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST, PROFILE web"
+
+
+def test_drop(user_exist, mock_execute):
+    changed = user_exist.drop(None)
+    actual_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert actual_query == "DROP USER 'alice'"


### PR DESCRIPTION
##### SUMMARY
Refactored codebase responsible for creating clause SETTINGS ... This part is shared between role and user so moved it to one class. This could be also easy reused for CREATE SETTINGS PROFILE in future.

`settings` parameter in role/user is now raw type and accepts both list(old way) or dictionary(new). In this dictionary keys are simply corresponding to settings elements in database.

It is much easier to normalize query and keep idempotency.

Fixes #178 