### PR TITLE
feat: new module clickhouse_named_collection

### DIFF
--- a/changelogs/fragments/197-module-named-collection.yml
+++ b/changelogs/fragments/197-module-named-collection.yml
@@ -1,2 +1,2 @@
 major_changes:
-  - clickhouse_named_collection - new module to add/modify/delete named collections in database
+  - clickhouse_named_collection - new module to add/modify/delete named collections in database.

--- a/changelogs/fragments/197-module-named-collection.yml
+++ b/changelogs/fragments/197-module-named-collection.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - clickhouse_named_collection - new module to add/modify/delete named collections in database

--- a/plugins/modules/clickhouse_named_collection.py
+++ b/plugins/modules/clickhouse_named_collection.py
@@ -89,7 +89,7 @@ EXAMPLES = r'''
       - name: password
         value: test_pass
 
-- name: Create named collection with forcing recreate
+- name: Create named collection with forcing rewrite
   community.clickhouse.clickhouse_named_collection:
     name: test_col
     collection:
@@ -97,7 +97,7 @@ EXAMPLES = r'''
         value: alice
       - name: password
         value: test_pass
-    recreate: true
+    rewrite: true
 
 - name: Drop named collection
   community.clickhouse.clickhouse_named_collection:

--- a/plugins/modules/clickhouse_named_collection.py
+++ b/plugins/modules/clickhouse_named_collection.py
@@ -1,0 +1,376 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Rafal Kozlowski (@rkozlo) <rafalkozlowski07@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: clickhouse_named_collection
+
+short_description: Creates, removes or modify a ClickHouse named collection using the clickhouse-driver Client interface
+
+description:
+  - Creates, remove or modify a ClickHouse named collection using the
+    L(clickhouse-driver,https://clickhouse-driver.readthedocs.io/en/latest) Client interface.
+  - The module can only work if O(login_user) will have necessary grants.
+  - An existing named collection can be modified only if server is properly configured and user is allowed to
+    L(view secrets,https://clickhouse.com/docs/sql-reference/statements/grant#displaysecretsinshowandselect).
+    There is an option to rewrite whole secret, but then it will not be idempotent.
+  - Module is supported only on version 25.8 or later.
+
+attributes:
+  check_mode:
+    description: Supports check_mode.
+    support: full
+
+author:
+  - Rafal Kozlowski (@rkozlo)
+
+extends_documentation_fragment:
+  - community.clickhouse.client_inst_opts
+
+version_added: '2.2.0'
+
+options:
+  state:
+    description:
+      - Named collection state.
+      - If C(present), will create or modify the named collection.
+      - If C(absent), will drop the named collection if exists.
+    type: str
+    choices: ['present', 'absent']
+    default: 'present'
+  name:
+    description:
+      - Named collection name to add or remove.
+    type: str
+    required: true
+  rewrite:
+    description:
+      - Force to rewrite secret. It has only use when viewing secrets is disabled and user can't fetch secrets values.
+      - If user can view secret values it will be fully idempotent. Will only alter collection if it differs.
+    type: bool
+    default: false
+  collection:
+    description:
+      - Content of named collection.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+          - Name of secret.
+        type: str
+        required: true
+      value:
+        description:
+          - Content of secret.
+        type: str
+        required: true
+  cluster:
+    description:
+      - Run the command on all cluster hosts.
+      - If the cluster is not configured, the command will crash with an error.
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Create named collection with 2 secrets
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass
+
+- name: Create named collection with forcing recreate
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass
+    recreate: true
+
+- name: Drop named collection
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    state: absent
+'''
+
+RETURN = r'''
+---
+executed_statements:
+  description:
+    - Data-modifying executed statements.
+  returned: on success
+  type: list
+  sample: ["CREATE NAMED COLLECTION `test_col` AS user = '********', password = '********'"]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse import (
+    check_clickhouse_driver,
+    client_common_argument_spec,
+    connect_to_db_via_client,
+    execute_query,
+    get_main_conn_kwargs,
+    get_server_version
+)
+
+executed_statements = []
+
+
+class ClickHouseNamedCollection:
+    def __init__(self, module, client, name):
+        self.module = module
+        self.client = client
+        self.name = name
+        self._exists = None
+        self._source = None
+        self._current = None
+
+    @property
+    def exists(self):
+        self._load()
+        return self._exists
+
+    @property
+    def source(self):
+        self._load()
+        return self._source
+
+    @property
+    def current(self):
+        self._load()
+        return self._current
+
+    def _load(self):
+        """Fetch info about passed collection"""
+        if self._exists is not None:
+            return
+
+        query = f"SELECT collection, source FROM system.named_collections WHERE name = '{self.name}'"
+        result = execute_query(self.module, self.client, query)
+
+        if not result:
+            self._exists = False
+            self._source = None
+            self._current = None
+            return
+
+        collection_data, source = result[0]
+        self._exists = True
+        self._source = source
+
+        if source == 'SQL':
+            self._current = self._normalize_current_collection_data(collection_data)
+        else:
+            self.module.fail_json(
+                msg=f"Passed named collection isn't sourced by SQL. Got: {source}"
+            )
+
+    def fetch(self):
+        """Get named collection paramters."""
+        if not self.exists:
+            return None
+
+        query = "SELECT collection, source FROM system.named_collections WHERE name = '%s'" % self.name
+        result = execute_query(self.module, self.client, query)
+        if result:
+            if result[0][1] != 'SQL':
+                self.module.fail_json(msg="Passed named collection isn't sourced by SQL. Got: '%s'" % result[0][1])
+            return result[0][0]
+        return None
+
+    def _normalize_current_collection_data(self, collection):
+        """Normalize raw db output into normalized form used in module options."""
+        """At this moment only support value field."""
+
+        result = {}
+        for key, value in collection.items():
+            result[key] = {'value': value}
+            self.module.no_log_values.add(value)
+        return result
+
+    def _check_if_hidden(self):
+        """Check normalized collection if hasn't hidden fields."""
+        """At this moment it can't be hidden in single key so we return on single element as whole."""
+        for key in self._current.values():
+            if key['value'] == '[HIDDEN]':
+                return True
+        return False
+
+    def _build_list_collection(self, collection):
+        parts = []
+        for name, content in collection.items():
+            for value in content.values():
+                parts.append("%s = '%s'" % (name, value))
+        return parts
+
+    def _should_skip_alter(self, collection, rewrite):
+        """Wheter preceed alter or not."""
+        hidden = self._check_if_hidden()
+
+        # Hidden means we can't determinie difference in key values.
+        if hidden and not rewrite:
+            return True
+
+        if self.current == collection:
+            return True
+        return False
+
+    def _build_alter_query(self, collection, cluster):
+        parts = self._build_list_collection(collection)
+        query = f"ALTER NAMED COLLECTION `{self.name}`"
+        if cluster:
+            query += f" ON CLUSTER '{cluster}'"
+        query += " SET " + ", ".join(parts)
+        return query
+
+    def create(self, collection, cluster):
+        if not collection:
+            self.module.fail_json(msg="Collection not passed")
+        query = "CREATE NAMED COLLECTION `%s`" % self.name
+        if cluster:
+            query += " ON CLUSTER '%s'" % cluster
+        query += " AS "
+        parts = self._build_list_collection(collection)
+        query += ", ".join(parts)
+
+        executed_statements.append(query)
+
+        if not self.module.check_mode:
+            execute_query(self.module, self.client, query)
+
+        return True
+
+    def drop(self, cluster):
+        query = "DROP NAMED COLLECTION `%s`" % self.name
+        if cluster:
+            query += " ON CLUSTER '%s'" % cluster
+
+        executed_statements.append(query)
+
+        if not self.module.check_mode:
+            execute_query(self.module, self.client, query)
+
+        return True
+
+    def alter(self, collection, cluster, rewrite):
+        if not collection:
+            self.module.fail_json(msg="Collection not passed")
+        if self._should_skip_alter(collection, rewrite):
+            return False
+
+        query = self._build_alter_query(collection, cluster)
+
+        executed_statements.append(query)
+
+        if not self.module.check_mode:
+            execute_query(self.module, self.client, query)
+        return True
+
+    def _normalize_collection_input(self, collection_list):
+        """Convert list of {name, value} to dict of {name: {value}}"""
+        if not collection_list:
+            return {}
+
+        normalized = {}
+        for item in collection_list:
+            name = item['name']
+            value = item['value']
+
+            # Handle duplicate names (last one wins or fail)
+            if name in normalized:
+                self.module.warn(f"Duplicate parameter '{name}', using last value")
+
+            normalized[name] = {'value': value}
+
+        return normalized
+
+
+def main():
+    # Set up arguments.
+    # If there are common arguments shared across several modules,
+    # create the common_argument_spec() function under plugins/module_utils/*
+    # and invoke here to return a dict with those arguments
+    argument_spec = client_common_argument_spec()
+    argument_spec.update(
+        state=dict(type="str", choices=["present", "absent"], default="present"),
+        name=dict(type="str", required=True),
+        cluster=dict(type='str', default=None),
+        collection=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                name=dict(type='str', required=True),
+                value=dict(type='str', required=True, no_log=True)
+            )
+        ),
+        rewrite=dict(type='bool', default=False)
+    )
+
+    # Conditional logic
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ('state', 'present', ['collection'], True)
+        ],
+    )
+
+    # Assign passed options to variables
+    client_kwargs = module.params["client_kwargs"]
+    # The reason why these arguments are separate from client_kwargs
+    # is that we need to protect some sensitive data like passwords passed
+    # to the module from logging (see the arguments above with no_log=True);
+    # Such data must be passed as module arguments (not nested deep in values).
+    main_conn_kwargs = get_main_conn_kwargs(module)
+    state = module.params["state"]
+    name = module.params["name"]
+    cluster = module.params["cluster"]
+    collection = module.params["collection"]
+    rewrite = module.params["rewrite"]
+
+    # Will fail if no driver informing the user
+    check_clickhouse_driver(module)
+
+    # Connect to DB
+    client = connect_to_db_via_client(module, main_conn_kwargs, client_kwargs)
+    server_version = get_server_version(module, client)
+
+    if server_version['year'] < 25 or (server_version['year'] == 25 and server_version['feature'] < 8):
+        module.fail_json(msg="Server version not supported. Require 25.8 or later.")
+
+    # Do the job
+    changed = False
+    named_collection = ClickHouseNamedCollection(module, client, name)
+    normalized_collection = named_collection._normalize_collection_input(collection)
+    if state == "present":
+        if not named_collection.exists:
+            changed = named_collection.create(normalized_collection, cluster)
+        else:
+            changed = named_collection.alter(normalized_collection, cluster, rewrite)
+    else:
+        # If state is absent
+        if named_collection.exists:
+            changed = named_collection.drop(cluster)
+
+    # Close connection
+    client.disconnect_connection()
+
+    # Users will get this in JSON output after execution
+    module.exit_json(changed=changed, executed_statements=executed_statements)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/clickhouse_named_collection/meta/main.yml
+++ b/tests/integration/targets/clickhouse_named_collection/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_clickhouse

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -10,7 +10,7 @@
 
 - name: End if not supported
   ansible.builtin.meta: end_play
-  when: 
+  when:
     - _info.version['year'] < 25 or (_info.version['year'] == 25 and _info.version['feature'] < 8)
 
 - name: Create test_user for named collections

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -101,7 +101,7 @@
     - result is not changed
     - result.executed_statements == []
 
-- name: Alter named collection in real mode - hidden 
+- name: Alter named collection in real mode - hidden
   community.clickhouse.clickhouse_named_collection:
     name: test_col
     collection:

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -198,7 +198,6 @@
     state: absent
   check_mode: true
   register: result
- 
 - name: Check the return values
   ansible.builtin.assert:
     that:

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -1,7 +1,7 @@
 ####################################################################
 # WARNING: These are designed specifically for Ansible tests       #
 # and should not be used as examples of how to write Ansible roles #
-####################################################################  
+####################################################################
 - name: Fetch clickhouse_version
   community.clickhouse.clickhouse_info:
     limit:

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -78,12 +78,13 @@
 - name: Check the collection was not created in check mode
   register: result
   community.clickhouse.clickhouse_client:
-    execute: "SELECT name FROM system.named_collections WHERE name = 'test_col'"
+    execute: "SELECT name, collection FROM system.named_collections WHERE name = 'test_col'"
+    login_user: test_user
 
 - name: Verify that the collection is present
   ansible.builtin.assert:
     that:
-    - result.result == [["test_col"]]
+    - 'result.result == [["test_col", {"user": "alice", "password": "test_pass"}]]'
 
 - name: Create named collection in real mode - idempotency
   community.clickhouse.clickhouse_named_collection:

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -210,7 +210,7 @@
   community.clickhouse.clickhouse_client:
     execute: "SELECT 1 FROM system.named_collections WHERE name = 'test_col'"
 
-- name: Verify that the collection is not present
+- name: Verify that the collection is present
   ansible.builtin.assert:
     that:
     - result.result == [[1]]

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -27,7 +27,6 @@
       - object: '*.*'
         privs:
           "ALL": true
-  
       - object: '*'
         privs:
           "NAMED COLLECTION ADMIN": true

--- a/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/initial.yml
@@ -1,0 +1,255 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################  
+- name: Fetch clickhouse_version
+  community.clickhouse.clickhouse_info:
+    limit:
+      - version
+  register: _info
+
+- name: End if not supported
+  ansible.builtin.meta: end_play
+  when: 
+    - _info.version['year'] < 25 or (_info.version['year'] == 25 and _info.version['feature'] < 8)
+
+- name: Create test_user for named collections
+  community.clickhouse.clickhouse_user:
+    name: test_user
+    settings:
+      - format_display_secrets_in_show_and_select=1
+
+- name: Grant test_user
+  community.clickhouse.clickhouse_grants:
+    state: present
+    grantee: test_user
+    privileges:
+      - object: '*.*'
+        privs:
+          "ALL": true
+  
+      - object: '*'
+        privs:
+          "NAMED COLLECTION ADMIN": true
+
+- name: Create named collection in check mode
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass
+  register: result
+  check_mode: true
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["CREATE NAMED COLLECTION `test_col` AS user = '********', password = '********'"]
+
+- name: Check the collection was not created in check mode
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT name FROM system.named_collections WHERE name = 'test_col'"
+
+- name: Verify that the collection is not present
+  ansible.builtin.assert:
+    that:
+    - result.result == []
+
+- name: Create named collection in real mode
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["CREATE NAMED COLLECTION `test_col` AS user = '********', password = '********'"]
+
+- name: Check the collection was not created in check mode
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT name FROM system.named_collections WHERE name = 'test_col'"
+
+- name: Verify that the collection is present
+  ansible.builtin.assert:
+    that:
+    - result.result == [["test_col"]]
+
+- name: Create named collection in real mode - idempotency
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Alter named collection in real mode - hidden 
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass2
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Alter named collection in real mode - hidden - force rewrite
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass2
+    rewrite: true
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER NAMED COLLECTION `test_col` SET user = '********', password = '********'"]
+
+- name: Check the collection was altered
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT collection FROM system.named_collections WHERE name = 'test_col'"
+    login_user: test_user
+
+- name: Verify that the collection has changed
+  ansible.builtin.assert:
+    that:
+    - result.result[0][0]['user'] == 'alice'
+    - result.result[0][0]['password'] == 'test_pass2'
+
+- name: Alter named collection in real mode show secrets 
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass3
+    login_user: test_user
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["ALTER NAMED COLLECTION `test_col` SET user = '********', password = '********'"]
+
+- name: Check the collection was altered
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT collection FROM system.named_collections WHERE name = 'test_col'"
+    login_user: test_user
+
+- name: Verify that the collection has changed
+  ansible.builtin.assert:
+    that:
+    - result.result[0][0]['user'] == 'alice'
+    - result.result[0][0]['password'] == 'test_pass3'
+
+- name: Alter named collection in real mode show secrets - idempotency
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    collection:
+      - name: user
+        value: alice
+      - name: password
+        value: test_pass3
+    login_user: test_user
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Drop named collection in check mode
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    state: absent
+  check_mode: true
+  register: result
+ 
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["DROP NAMED COLLECTION `test_col`"]
+
+- name: Check the collection was not dropped in check mode
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT 1 FROM system.named_collections WHERE name = 'test_col'"
+
+- name: Verify that the collection is not present
+  ansible.builtin.assert:
+    that:
+    - result.result == [[1]]
+
+- name: Drop named collection in real mode
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    state: absent
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ["DROP NAMED COLLECTION `test_col`"]
+
+- name: Check the collection was dropped in real mode
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT 1 FROM system.named_collections WHERE name = 'test_col'"
+
+- name: Verify that the collection is not present
+  ansible.builtin.assert:
+    that:
+    - result.result == []
+
+- name: Drop named collection in real mode - idempotency
+  community.clickhouse.clickhouse_named_collection:
+    name: test_col
+    state: absent
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+    - result.executed_statements == []
+
+- name: Drop test_user used to manage named collections
+  community.clickhouse.clickhouse_user:
+    name: test_user
+    state: absent

--- a/tests/integration/targets/clickhouse_named_collection/tasks/main.yml
+++ b/tests/integration/targets/clickhouse_named_collection/tasks/main.yml
@@ -1,0 +1,7 @@
+####################################################################
+# WARNING: These are designed specifically for Ansible tests       #
+# and should not be used as examples of how to write Ansible roles #
+####################################################################
+
+# Initial CI tests of clickhouse_info module
+- import_tasks: initial.yml

--- a/tests/integration/targets/setup_clickhouse/files/default_user.xml
+++ b/tests/integration/targets/setup_clickhouse/files/default_user.xml
@@ -8,6 +8,9 @@
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
     </users>
 </yandex>

--- a/tests/integration/targets/setup_clickhouse/tasks/install.yml
+++ b/tests/integration/targets/setup_clickhouse/tasks/install.yml
@@ -72,6 +72,14 @@
           <background_schedule_pool_size>16</background_schedule_pool_size>
       </clickhouse>
 
+- name: Configure clickhouse for testing named collections
+  ansible.builtin.copy:
+    dest: /etc/clickhouse-server/config.d/named_collections.xml
+    content: |
+      <clickhouse>
+        <display_secrets_in_show_and_select>1</display_secrets_in_show_and_select>
+      </clickhouse>
+
 - name: Enable and start clickhouse server
   ansible.builtin.systemd_service:
     name: clickhouse-server

--- a/tests/unit/plugins/modules/test_clickhouse_named_collection.py
+++ b/tests/unit/plugins/modules/test_clickhouse_named_collection.py
@@ -1,0 +1,261 @@
+from __future__ import absolute_import, division, print_function
+import pytest
+from ansible_collections.community.clickhouse.plugins.modules.clickhouse_named_collection import ClickHouseNamedCollection
+
+
+@pytest.fixture
+def collection(mocker):
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+
+    return ClickHouseNamedCollection(module=mock_module, client=mock_client, name="test_collection")
+
+
+def get_executed_query(mock_execute):
+    # Assumes execute_query(module, client, query, params)
+    args, kwargs = mock_execute.call_args
+    return args[2] if len(args) > 2 else kwargs.get('query')
+
+
+@pytest.fixture
+def mock_execute(mocker):
+    return mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_named_collection.execute_query",
+        return_value=[]
+    )
+
+
+def test_fetch_collection_not_exists(collection, mock_execute):
+    collection._load()
+
+    assert collection.exists is False
+    assert mock_execute.call_count == 1
+
+
+def test_fetch_collection_exists(collection, mocker):
+    mock_execute = mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_named_collection.execute_query",
+        return_value=[({'a': 'b'}, 'SQL')]
+    )
+    collection._load()
+
+    assert mock_execute.call_count == 1
+    assert collection.exists is True
+    assert collection.source == 'SQL'
+    assert collection.current == {'a': {'value': 'b'}}
+
+
+def test_fetch_collection_exists_not_supported(collection, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_named_collection.execute_query",
+        return_value=[
+            ({'password': '[HIDDEN]', 'user': '[HIDDEN]'}, 'XML')
+        ]
+    )
+    collection.module.fail_json.side_effect = Exception("fail_json called")
+
+    with pytest.raises(Exception, match="fail_json called"):
+        collection._load()
+    collection.module.fail_json.assert_called_once()
+
+    assert "Passed named collection isn't sourced by SQL. Got: XML" in collection.module.fail_json.call_args[1]['msg']
+
+
+def test_normalize_current_collection(collection, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_named_collection.execute_query",
+        return_value=[
+            ({'password': '[HIDDEN]', 'user': '[HIDDEN]'}, 'SQL')
+        ]
+    )
+    collection._load()
+
+    assert collection._current == {'password': {'value': '[HIDDEN]'}, 'user': {'value': '[HIDDEN]'}}
+
+
+def test_normalized_input_collection(collection):
+
+    result = collection._normalize_collection_input(
+        [
+            {'name': 'user', 'value': 'alice'},
+            {'name': 'password', 'value': 'test_pass'}
+        ]
+    )
+    assert result == {'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}
+
+
+def test_check_hidden_passed_hidden(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': '[HIDDEN]'}, 'user': {'value': '[HIDDEN]'}}
+    result = collection._check_if_hidden()
+    assert result is True
+
+
+def test_check_hidden_passed_not_hidden(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': 'test_pass'}, 'user': {'value': 'alice'}}
+    result = collection._check_if_hidden()
+    assert result is False
+
+
+def test_should_skip_alter_hidden(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': '[HIDDEN]'}, 'user': {'value': '[HIDDEN]'}}
+    skipped = collection._should_skip_alter({'user': {'value': 'alice'}}, False)
+    assert skipped is True
+
+
+def test_should_skip_alter_rewrite(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': '[HIDDEN]'}, 'user': {'value': '[HIDDEN]'}}
+    skipped = collection._should_skip_alter({'user': {'value': 'alice'}}, True)
+    assert skipped is False
+
+
+def test_should_skip_alter_equal(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': 'test_pass'}, 'user': {'value': 'alice'}}
+    skipped = collection._should_skip_alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, False)
+    assert skipped is True
+
+
+def test_should_skip_alter_not_equal(collection):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'password': {'value': 'test_pass'}, 'user': {'value': 'alice'}}
+    skipped = collection._should_skip_alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass2'}}, False)
+    assert skipped is False
+
+
+def test_build_alter_query_single(collection):
+    query = collection._build_alter_query({'user': {'value': 'alice'}}, None)
+    assert query == "ALTER NAMED COLLECTION `test_collection` SET user = 'alice'"
+
+
+def test_build_alter_query_double(collection):
+    query = collection._build_alter_query({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, None)
+    assert query == "ALTER NAMED COLLECTION `test_collection` SET user = 'alice', password = 'test_pass'"
+
+
+def test_build_alter_query_double_plus_cluster(collection):
+    query = collection._build_alter_query({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, 'north')
+    assert query == "ALTER NAMED COLLECTION `test_collection` ON CLUSTER 'north' SET user = 'alice', password = 'test_pass'"
+
+
+def test_create_collection_empty_params(collection):
+    collection._exist = False
+
+    collection.module.fail_json.side_effect = Exception("fail_json called")
+
+    with pytest.raises(Exception, match="fail_json called"):
+        collection.create({}, None)
+    collection.module.fail_json.assert_called_once()
+
+    assert "Collection not passed" in collection.module.fail_json.call_args[1]['msg']
+
+
+def test_create_collection_with_one_param(collection, mock_execute):
+    collection._exist = False
+    changed = collection.create({'user': {'value': 'alice'}}, None)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "CREATE NAMED COLLECTION `test_collection` AS user = 'alice'"
+
+
+def test_create_collection_with_two_param(collection, mock_execute):
+    changed = collection.create({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, None)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "CREATE NAMED COLLECTION `test_collection` AS user = 'alice', password = 'test_pass'"
+
+
+def test_create_collection_with_three_param_plus_cluster(collection, mock_execute):
+    changed = collection.create({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}, 'host': {'value': 'host1'}}, 'north')
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "CREATE NAMED COLLECTION `test_collection` ON CLUSTER 'north' AS user = 'alice', password = 'test_pass', host = 'host1'"
+
+
+def test_alter_collection_empty_params(collection):
+    collection._exist = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}
+
+    collection.module.fail_json.side_effect = Exception("fail_json called")
+
+    with pytest.raises(Exception, match="fail_json called"):
+        collection.alter({}, None, False)
+    collection.module.fail_json.assert_called_once()
+
+    assert "Collection not passed" in collection.module.fail_json.call_args[1]['msg']
+
+
+def test_alter_collection_no_hidden_with_one_param(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}
+    changed = collection.alter({'user': {'value': 'alice'}}, None, False)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "ALTER NAMED COLLECTION `test_collection` SET user = 'alice'"
+
+
+def test_alter_collection_no_hidden_with_two_param(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}
+    changed = collection.alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass2'}}, None, False)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "ALTER NAMED COLLECTION `test_collection` SET user = 'alice', password = 'test_pass2'"
+
+
+def test_alter_collection_no_hidden_no_changes(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}
+    changed = collection.alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, None, False)
+    assert changed is False
+    assert mock_execute.call_count == 0
+
+
+def test_alter_collection_hidden(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': '[HIDDEN]'}, 'password': {'value': '[HIDDEN]'}}
+    changed = collection.alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, None, False)
+    assert changed is False
+    assert mock_execute.call_count == 0
+
+
+def test_alter_collection_hidden_rewrite(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': '[HIDDEN]'}, 'password': {'value': '[HIDDEN]'}}
+    changed = collection.alter({'user': {'value': 'alice'}, 'password': {'value': 'test_pass'}}, None, True)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "ALTER NAMED COLLECTION `test_collection` SET user = 'alice', password = 'test_pass'"
+
+
+def test_drop_collection(collection, mock_execute):
+    collection._exists = True
+    collection._source = 'SQL'
+    collection._current = {'user': {'value': '[HIDDEN]'}, 'password': {'value': '[HIDDEN]'}}
+    changed = collection.drop(None)
+    actuall_query = get_executed_query(mock_execute)
+    assert changed is True
+    assert mock_execute.call_count == 1
+    assert actuall_query == "DROP NAMED COLLECTION `test_collection`"


### PR DESCRIPTION
##### SUMMARY

Add new module for managin named collections.
Module require version 25.8 or later.
Named collection is verified what source of it is. If it is not sourced by SQL that means it was created in files, mostly XML files so this error is handled. For that is used column `source` from system.named_collections which was introduced in 25.5. 25.8 is oldest supported LTS so decided to point that version.

New module should be fully idempotent.
For storing collection inside module used dict of dicts instead of dict of strings because probably it will have new parameters in future so in this way it will be easier to implement. At this moment it has [NOT] OVERRIDABLE parameter for each secret, but it is not stored in structured way(only SQL) so decided for now leave it to keep it simple and not risking breaking idempotency.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
clickhouse_named_collection
