### PR TITLE
refactor: improve db module validation

### DIFF
--- a/changelogs/fragments/214-clickhouse-db-improve-validation.yml
+++ b/changelogs/fragments/214-clickhouse-db-improve-validation.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - clickhouse_db - validate passed identifiers. Close them in backticks to keep it consistent with other modules.
-  - clickhouse_db - check if passed engine is supported before executing query. Module checks if passed name exists in system.database_engines.
+  - clickhouse_db - validate passed identifiers. Close them in backticks to keep it consistent with other modules (https://github.com/ansible-collections/community.clickhouse/pull/214).
+  - clickhouse_db - check if passed engine is supported before executing query. Module checks if passed name exists in system.database_engines (https://github.com/ansible-collections/community.clickhouse/pull/214).

--- a/changelogs/fragments/214-clickhouse-db-improve-validation.yml
+++ b/changelogs/fragments/214-clickhouse-db-improve-validation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - clickhouse_db - validate passed identifiers. Close them in backticks to keep it consistent with other modules.
+  - clickhouse_db - check if passed engine is supported before executing query. Module checks if passed name exists in system.database_engines.

--- a/plugins/modules/clickhouse_db.py
+++ b/plugins/modules/clickhouse_db.py
@@ -130,6 +130,8 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     execute_query,
     get_main_conn_kwargs,
     get_server_version,
+    validate_identifier,
+    get_on_cluster_clause,
 )
 
 
@@ -140,6 +142,7 @@ class ClickHouseDB():
     def __init__(self, module, client, name, cluster, comment):
         self.module = module
         self.client = client
+        validate_identifier(module, name, "db name")
         self.name = name
         self.cluster = cluster
         # Set default values, then update
@@ -172,12 +175,19 @@ class ClickHouseDB():
             if server_version['year'] >= 22:
                 self.comment = result[0][1]
 
-    def create(self, engine, comment):
-        query = "CREATE DATABASE %s" % self.name
-        if self.cluster:
-            query += " ON CLUSTER %s" % self.cluster
+    def _validate_db_engine(self, target_engine):
+        '''Prevent executing incorrect queries.'''
+        query = "SELECT 1 FROM system.database_engines WHERE name = %(engine)s"
+        exec_kwargs = {'params': {'engine': target_engine}}
+        result = execute_query(self.module, self.client, query, exec_kwargs)
+        if not result:
+            self.module.fail_json(msg=f"Passed engine {target_engine} is not supported by current version.")
 
+    def create(self, engine, comment):
+        query = "CREATE DATABASE `%s`" % self.name
+        query += get_on_cluster_clause(self.module, self.cluster)
         if engine:
+            self._validate_db_engine(engine)
             query += " ENGINE = %s" % engine
 
         if comment:
@@ -213,9 +223,9 @@ class ClickHouseDB():
                        'versions equal to or higher than 22.*. Ignored.')
                 self.module.warn(msg)
             elif (server_version['year'] == 25 and server_version['feature'] >= 8) or server_version['year'] >= 26:
-                query = "ALTER DATABASE %s" % self.name
+                query = "ALTER DATABASE `%s`" % self.name
                 if self.cluster:
-                    query += " ON CLUSTER %s" % self.cluster
+                    query += get_on_cluster_clause(self.module, self.cluster)
                 query += " MODIFY COMMENT '%s'" % comment
 
                 executed_statements.append(query)
@@ -233,9 +243,9 @@ class ClickHouseDB():
         return False
 
     def rename(self, target):
-        query = "RENAME DATABASE %s TO %s" % (self.name, target)
-        if self.cluster:
-            query += " ON CLUSTER %s" % self.cluster
+        validate_identifier(self.module, target, "db name")
+        query = "RENAME DATABASE `%s` TO `%s`" % (self.name, target)
+        query += get_on_cluster_clause(self.module, self.cluster)
 
         executed_statements.append(query)
 
@@ -245,9 +255,8 @@ class ClickHouseDB():
         return True
 
     def drop(self):
-        query = "DROP DATABASE %s" % self.name
-        if self.cluster:
-            query += " ON CLUSTER %s" % self.cluster
+        query = "DROP DATABASE `%s`" % self.name
+        query += get_on_cluster_clause(self.module, self.cluster)
 
         executed_statements.append(query)
 

--- a/tests/integration/targets/clickhouse_db/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_db/tasks/initial.yml
@@ -15,7 +15,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE DATABASE test_db']
+    - result.executed_statements == ['CREATE DATABASE `test_db`']
 
 - name: Check the actual state
   register: result
@@ -40,7 +40,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE DATABASE test_db ENGINE = Memory"]
+    - result.executed_statements == ["CREATE DATABASE `test_db` ENGINE = Memory"]
 
 - name: Check the actual state
   register: result
@@ -63,7 +63,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE DATABASE test_db ENGINE = Memory"]
+    - result.executed_statements == ["CREATE DATABASE `test_db` ENGINE = Memory"]
 
 - name: Check the actual state
   register: result
@@ -161,7 +161,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["DROP DATABASE test_db"]
+    - result.executed_statements == ["DROP DATABASE `test_db`"]
 
 - name: Check the actual state
   register: result
@@ -184,7 +184,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["DROP DATABASE test_db"]
+    - result.executed_statements == ["DROP DATABASE `test_db`"]
 
 - name: Check the actual state
   register: result
@@ -240,7 +240,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["RENAME DATABASE test_rename_db TO dev_db"]
+    - result.executed_statements == ["RENAME DATABASE `test_rename_db` TO `dev_db`"]
 
 # Test
 - name: Rename database in check mode
@@ -255,7 +255,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["RENAME DATABASE dev_db TO test_rename_db"]
+    - result.executed_statements == ["RENAME DATABASE `dev_db` TO `test_rename_db`"]
 
 # Test rename database if there is nothing to rename
 - name: Rename database if there is nothing to rename
@@ -314,7 +314,7 @@
     ansible.builtin.assert:
       that:
       - result is changed
-      - result.executed_statements == ["CREATE DATABASE test_db COMMENT 'Test DB'"]
+      - result.executed_statements == ["CREATE DATABASE `test_db` COMMENT 'Test DB'"]
 
   # Test
   - name: Create database with comment real mode
@@ -328,7 +328,7 @@
     ansible.builtin.assert:
       that:
       - result is changed
-      - result.executed_statements == ["CREATE DATABASE test_db COMMENT 'Test DB'"]
+      - result.executed_statements == ["CREATE DATABASE `test_db` COMMENT 'Test DB'"]
 
   - name: Check the actual state
     register: result
@@ -359,7 +359,7 @@
         ansible.builtin.assert:
           that:
             - result is changed
-            - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
+            - result.executed_statements == ["ALTER DATABASE `test_db` MODIFY COMMENT 'Test DB 1'"]
 
       - name: Check the actual state
         register: result
@@ -382,7 +382,7 @@
         ansible.builtin.assert:
           that:
           - result is changed
-          - result.executed_statements == ["ALTER DATABASE test_db MODIFY COMMENT 'Test DB 1'"]
+          - result.executed_statements == ["ALTER DATABASE `test_db` MODIFY COMMENT 'Test DB 1'"]
 
       - name: Check the actual state
         register: result
@@ -487,3 +487,17 @@
     ansible.builtin.assert:
       that:
       - result is changed
+
+  - name: Create db with fake engine
+    community.clickhouse.clickhouse_db:
+      state: present
+      name: test_db
+      engine: Fake
+    ignore_errors: true
+    register: result
+
+  - name: Check ret values
+    ansible.builtin.assert:
+      that:
+      - result is failed
+      - result.msg == "Passed engine Fake is not supported by current version."

--- a/tests/unit/plugins/modules/test_clickhouse_db.py
+++ b/tests/unit/plugins/modules/test_clickhouse_db.py
@@ -16,6 +16,7 @@ def _create_db(mocker, name="test_db", cluster=None, comment=None, version=None)
     mock_module.check_mode = False
     mock_client = mocker.MagicMock()
     mocker.patch('ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.get_server_version', return_value=version)
+    mocker.patch('ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.validate_identifier', return_value=None)
 
     return ClickHouseDB(
         module=mock_module,
@@ -43,35 +44,35 @@ def test_plain_db_with_default_options(db_factory, mock_execute):
     db = db_factory()
     db.create(engine=None, comment=None)
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE DATABASE test_db"
+    assert actual_query == "CREATE DATABASE `test_db`"
 
 
 def test_plain_db_with_options(db_factory, mock_execute):
     db = db_factory()
     db.create(engine='Ordinary', comment='test comment')
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE DATABASE test_db ENGINE = Ordinary COMMENT 'test comment'"
+    assert actual_query == "CREATE DATABASE `test_db` ENGINE = Ordinary COMMENT 'test comment'"
 
 
 def test_altering_existing_database_comment(db_factory, mock_execute):
     db = db_factory()
     db.update(engine=None, comment='test comment2')
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "ALTER DATABASE test_db MODIFY COMMENT 'test comment2'"
+    assert actual_query == "ALTER DATABASE `test_db` MODIFY COMMENT 'test comment2'"
 
 
 def test_renaming_database(db_factory, mock_execute):
     db = db_factory()
     db.rename(target='test_db2')
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "RENAME DATABASE test_db TO test_db2"
+    assert actual_query == "RENAME DATABASE `test_db` TO `test_db2`"
 
 
 def test_droping_database(db_factory, mock_execute):
     db = db_factory()
     db.drop()
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "DROP DATABASE test_db"
+    assert actual_query == "DROP DATABASE `test_db`"
 
 
 def test_altering_database_comment_not_supported(db_factory, mocker):
@@ -89,3 +90,17 @@ def test_altering_database_comment_not_supported(db_factory, mocker):
 
     db.module.warn.assert_called_once()
     mock_execute.assert_not_called()
+
+
+def test_db_engine_supported(db_factory, mocker):
+    db = db_factory()
+    mocker.patch('ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.execute_query', return_value=[[1]])
+    db._validate_db_engine('Test engine')
+    db.module.fail_json.assert_not_called()
+
+
+def test_db_engine_not_supported(db_factory, mocker):
+    db = db_factory()
+    mocker.patch('ansible_collections.community.clickhouse.plugins.modules.clickhouse_db.execute_query', return_value=[])
+    db._validate_db_engine('Test engine')
+    db.module.fail_json.assert_called_once()


### PR DESCRIPTION
##### SUMMARY
Validate identifiers using existing functions introduced in previos PR. Names will be closed with backticks to keep it consistent with other modules.
Fetch info about supported db engines in server and handle this on module side instead of sending incorrect query to server.

Comment is for unresolvable for now. It can't be passed as parameter. Attempt harden this against sql-injection can easily break idempotency or introduce breaking changes, so it is addressed for another PR in future.
