### PR TITLE
chore: deprecate warning settings as list

### DIFF
--- a/changelogs/fragments/218-deprecate-settings-as-list.yml
+++ b/changelogs/fragments/218-deprecate-settings-as-list.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - clickhouse_user - list based settings and profiles are marked as deprecated and sheduled for removal in 3.0.0 (https://github.com/ansible-collections/community.clickhouse/issues/218).
+  - clickhouse_role - list based settings and profiles are marked as deprecated and sheduled for removal in 3.0.0 (https://github.com/ansible-collections/community.clickhouse/issues/218).

--- a/plugins/modules/clickhouse_role.py
+++ b/plugins/modules/clickhouse_role.py
@@ -373,6 +373,11 @@ def main():
             # Role exists, check if settings need to be updated
             if isinstance(desired_settings, list):
                 if desired_settings is not None and len(desired_settings) > 0:  # Only check settings if they are specified and not empty
+                    module.deprecate(
+                        msg="List based settings are deprecated. Use dictionary instead.",
+                        version="3.0.0",
+                        collection_name="community.clickhouse",
+                    )
                     current_definition = role.get_current_role_definition()
                     current_settings = role.parse_settings_from_create_statement(current_definition) if current_definition else []
 

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -505,6 +505,11 @@ class ClickHouseUser():
 
         if settings or profiles:
             if isinstance(settings, list):
+                self.module.deprecate(
+                    msg="List based settings are deprecated. Use dictionary instead.",
+                    version="3.0.0",
+                    collection_name="community.clickhouse",
+                )
                 query += " SETTINGS"
                 for index, value in enumerate(settings):
                     query += " %s" % value
@@ -750,6 +755,11 @@ class ClickHouseUser():
         """Update user settings idempotently by comparing with current settings"""
 
         if isinstance(settings, list):
+            self.module.deprecate(
+                msg="List based settings are deprecated. Use dictionary instead.",
+                version="3.0.0",
+                collection_name="community.clickhouse",
+            )
             # Parse desired settings into a comparable format
             desired_settings = {}
             desired_profiles = []


### PR DESCRIPTION
##### SUMMARY
Deprecate warning for old settings. New version uses dictionary.

##### ISSUE TYPE
- chore

##### COMPONENT NAME
- clickhouse_user
- clickhouse_role
