### PR TITLE
refactor: normalize passing names to db

### DIFF
--- a/changelogs/fragments/221-hardening-role-names.yml
+++ b/changelogs/fragments/221-hardening-role-names.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - clickhouse_role - close names in backticks. Now names for roles and cluster will be validated. Those containing ` or \ will be rejected. Other will eb safe passed without risk of breaking query.

--- a/plugins/modules/clickhouse_role.py
+++ b/plugins/modules/clickhouse_role.py
@@ -131,6 +131,8 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     connect_to_db_via_client,
     execute_query,
     get_main_conn_kwargs,
+    validate_identifier,
+    get_on_cluster_clause,
 )
 from ansible_collections.community.clickhouse.plugins.module_utils.entity_settings import EntitySettings
 executed_statements = []
@@ -140,13 +142,15 @@ class ClickHouseRole:
     def __init__(self, module, client, name):
         self.module = module
         self.client = client
+        validate_identifier(self.module, name)
         self.name = name
         self.settings = EntitySettings(self.module, self.client, self.name, 'role')
         self.exists = self.check_exists()
 
     def check_exists(self):
-        query = "SELECT 1 FROM system.roles WHERE name = '%s' LIMIT 1" % self.name
-        result = execute_query(self.module, self.client, query)
+        query = "SELECT 1 FROM system.roles WHERE name = %(name)s LIMIT 1"
+        exec_kwargs = {'params': {'name': self.name}}
+        result = execute_query(self.module, self.client, query, exec_kwargs)
         return bool(result)
 
     def get_current_role_definition(self):
@@ -154,7 +158,7 @@ class ClickHouseRole:
         if not self.exists:
             return None
 
-        query = "SHOW CREATE ROLE %s" % self.name
+        query = "SHOW CREATE ROLE `%s`" % self.name
         result = execute_query(self.module, self.client, query)
         if result:
             return result[0][0]  # SHOW CREATE ROLE returns single row with CREATE statement
@@ -248,10 +252,9 @@ class ClickHouseRole:
 
     def create(self, cluster):
         if not self.exists:
-            query = "CREATE ROLE %s" % self.name
+            query = "CREATE ROLE `%s`" % self.name
 
-            if cluster:
-                query += " ON CLUSTER %s" % cluster
+            query += get_on_cluster_clause(self.module, cluster)
 
             if isinstance(self.module.params['settings'], list):
                 list_settings = self.module.params['settings']
@@ -280,10 +283,9 @@ class ClickHouseRole:
         if not self.exists:
             return False
 
-        query = "ALTER ROLE %s" % self.name
+        query = "ALTER ROLE `%s`" % self.name
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query += get_on_cluster_clause(self.module, cluster)
 
         if isinstance(settings, list):
             # Handle settings updates
@@ -309,9 +311,8 @@ class ClickHouseRole:
 
     def drop(self, cluster):
         if self.exists:
-            query = "DROP ROLE %s" % self.name
-            if cluster:
-                query += " ON CLUSTER %s" % cluster
+            query = "DROP ROLE `%s`" % self.name
+            query += get_on_cluster_clause(self.module, cluster)
 
             executed_statements.append(query)
 

--- a/tests/integration/targets/clickhouse_role/tasks/advanced.yml
+++ b/tests/integration/targets/clickhouse_role/tasks/advanced.yml
@@ -17,7 +17,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE ROLE simple_role']
+    - result.executed_statements == ['CREATE ROLE `simple_role`']
 
 - name: Advanced Test 1 - Create role without settings in real mode
   register: result
@@ -29,7 +29,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE ROLE simple_role']
+    - result.executed_statements == ['CREATE ROLE `simple_role`']
 
 - name: Advanced Test 1 - Verify role exists
   register: result
@@ -65,7 +65,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER ROLE simple_role SETTINGS max_memory_usage = 10000 READONLY']
+    - result.executed_statements == ['ALTER ROLE `simple_role` SETTINGS max_memory_usage = 10000 READONLY']
 
 - name: Advanced Test 2 - Verify settings not applied in check mode
   register: result
@@ -89,7 +89,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER ROLE simple_role SETTINGS max_memory_usage = 10000 READONLY']
+    - result.executed_statements == ['ALTER ROLE `simple_role` SETTINGS max_memory_usage = 10000 READONLY']
 
 - name: Advanced Test 2 - Verify settings were applied
   register: result

--- a/tests/integration/targets/clickhouse_role/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_role/tasks/initial.yml
@@ -15,7 +15,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE ROLE test_role']
+    - result.executed_statements == ['CREATE ROLE `test_role`']
 
 - name: Test 1 - Check the role was not created in check mode
   register: result
@@ -41,7 +41,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE ROLE test_role SETTINGS max_memory_usage = 15000 READONLY, max_memory_usage_for_all_queries = 15000 MIN 15000 MAX 16000 WRITABLE']
+    - result.executed_statements == ['CREATE ROLE `test_role` SETTINGS max_memory_usage = 15000 READONLY, max_memory_usage_for_all_queries = 15000 MIN 15000 MAX 16000 WRITABLE']
 
 - name: Test 2 - Check the role was created
   register: result
@@ -97,7 +97,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER ROLE test_role SETTINGS max_memory_usage = 20000 READONLY, max_threads = 8']
+    - result.executed_statements == ['ALTER ROLE `test_role` SETTINGS max_memory_usage = 20000 READONLY, max_threads = 8']
 
 - name: Test 4 - Verify settings were not changed in check mode
   register: result
@@ -124,7 +124,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER ROLE test_role SETTINGS max_memory_usage = 20000 READONLY, max_threads = 8']
+    - result.executed_statements == ['ALTER ROLE `test_role` SETTINGS max_memory_usage = 20000 READONLY, max_threads = 8']
 
 - name: Test 5 - Verify settings were updated in database
   register: result
@@ -193,7 +193,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER ROLE test_role SETTINGS max_memory_usage = 25000 READONLY, max_threads = 16, PROFILE \'default\'']
+    - result.executed_statements == ['ALTER ROLE `test_role` SETTINGS max_memory_usage = 25000 READONLY, max_threads = 16, PROFILE \'default\'']
 
 - name: Test 8 - Verify multiple settings in database
   register: result
@@ -220,7 +220,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['DROP ROLE test_role']
+    - result.executed_statements == ['DROP ROLE `test_role`']
 
 - name: Test 9 - Check the role was not removed in check mode
   register: result
@@ -243,7 +243,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['DROP ROLE test_role']
+    - result.executed_statements == ['DROP ROLE `test_role`']
 
 - name: Test 10 - Check the role was removed in real mode
   register: result
@@ -288,7 +288,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE ROLE test_role SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
+    - result.executed_statements == ["CREATE ROLE `test_role` SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
 
 - name: Test 12 - Check the role was created
   register: result
@@ -349,7 +349,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE ROLE test_role SETTINGS PROFILE 'web', PROFILE 'app'"]
+    - result.executed_statements == ["CREATE ROLE `test_role` SETTINGS PROFILE 'web', PROFILE 'app'"]
 
 - name: Test 13 - Check the role was created
   register: result
@@ -388,7 +388,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER ROLE test_role SETTINGS PROFILE 'web'"]
+    - result.executed_statements == ["ALTER ROLE `test_role` SETTINGS PROFILE 'web'"]
 
 - name: Test 13 - Alter role removing settings with settings as dictionary - workaround 
   register: result
@@ -401,7 +401,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER ROLE test_role SETTINGS NONE"]
+    - result.executed_statements == ["ALTER ROLE `test_role` SETTINGS NONE"]
 
 - name: Test 13 - Alter role removing settings with settings as dictionary - idempotency
   register: result
@@ -447,7 +447,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE ROLE test_role ON CLUSTER default"]
+    - result.executed_statements == ["CREATE ROLE `test_role` ON CLUSTER `default`"]
 
 - name: Test 14 - Alter role on cluster
   register: result
@@ -463,7 +463,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER ROLE test_role ON CLUSTER default SETTINGS max_threads='1'"]
+    - result.executed_statements == ["ALTER ROLE `test_role` ON CLUSTER `default` SETTINGS max_threads='1'"]
 
 - name: Test 14 - Drop role on cluster
   register: result
@@ -476,4 +476,4 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["DROP ROLE test_role ON CLUSTER default"]
+    - result.executed_statements == ["DROP ROLE `test_role` ON CLUSTER `default`"]

--- a/tests/unit/plugins/modules/test_clickhouse_role.py
+++ b/tests/unit/plugins/modules/test_clickhouse_role.py
@@ -36,7 +36,7 @@ def test_alter_role_one_setting_old_setting(role, mock_execute):
     changed = role.alter(["max_memory_usage='10G'"], [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10G'"
 
 
 def test_alter_role_one_setting_new_setting(role, mock_execute, mocker):
@@ -47,35 +47,35 @@ def test_alter_role_one_setting_new_setting(role, mock_execute, mocker):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10G'"
 
 
 def test_alter_role_one_profile_new_setting(role, mock_execute):
     changed = role.alter({}, ['web'], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS PROFILE 'web'"
 
 
 def test_alter_role_one_profile_one_setting_new_setting(role, mock_execute):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, ['web'], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web', max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS PROFILE 'web', max_memory_usage='10G'"
 
 
 def test_drop(role, mock_execute):
     changed = role.drop(None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "DROP ROLE test_role"
+    assert actual_query == "DROP ROLE `test_role`"
 
 
 def test_drop_on_cluster(role, mock_execute):
     changed = role.drop('test_cluster')
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "DROP ROLE test_role ON CLUSTER test_cluster"
+    assert actual_query == "DROP ROLE `test_role` ON CLUSTER `test_cluster`"
 
 
 def test_alter_role_none_settings_nor_profile(role, mock_execute, mocker):
@@ -84,7 +84,7 @@ def test_alter_role_none_settings_nor_profile(role, mock_execute, mocker):
     changed = role.alter({}, [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS NONE"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS NONE"
 
 
 def test_alter_role_del_settings_add_profile(role, mock_execute, mocker):
@@ -93,7 +93,7 @@ def test_alter_role_del_settings_add_profile(role, mock_execute, mocker):
     changed = role.alter({}, ['web'], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS PROFILE 'web'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS PROFILE 'web'"
 
 
 def test_alter_role_add_settings_del_profile(role, mock_execute, mocker):
@@ -102,4 +102,4 @@ def test_alter_role_add_settings_del_profile(role, mock_execute, mocker):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE test_role SETTINGS max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10G'"


### PR DESCRIPTION
##### SUMMARY
Continue refactoring.

Close role and cluster name with backticks.
Validate if they contain not allowed characters.

##### ISSUE TYPE
- Chore
##### COMPONENT NAME
- clickhouse_role