### PR TITLE
refactor(user): normalize user module

### DIFF
--- a/changelogs/fragments/222-refactor-normalizng-user-module.yml
+++ b/changelogs/fragments/222-refactor-normalizng-user-module.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - clickhouse_user - normalize generating query. Now identifiers like user names will be closed in backticks.
+  - clickhouse_user - pass password to ClickHouse using query parameters. Prevent breaking query when containing soem special characters.
+  - clickhouse_user - module on success returns query_parameters with password used for query.

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -375,6 +375,7 @@ query_parameters:
   returned: on succes
   type: list
   sample: [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
+  version_added: '2.3.0'
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/clickhouse_user.py
+++ b/plugins/modules/clickhouse_user.py
@@ -36,6 +36,7 @@ author:
 
 extends_documentation_fragment:
   - community.clickhouse.client_inst_opts
+  - community.clickhouse.cluster_inst_opts
 
 version_added: '0.4.0'
 
@@ -99,11 +100,6 @@ options:
         description:
           - Password or hash.
         type: str
-  cluster:
-    description:
-      - Run the command on all cluster hosts.
-      - If the cluster is not configured, the command will crash with an error.
-    type: str
   update_password:
     description:
       - If C(on_create), will set the password only for newly created users.
@@ -372,7 +368,13 @@ executed_statements:
   - Data-modifying executed statements.
   returned: on success
   type: list
-  sample: ["CREATE USER test_user IDENTIFIED WITH ***** BY '*****'"]
+  sample: ["CREATE USER test_user IDENTIFIED WITH sha256_hash BY %(password)s"]
+query_parameters:
+  description:
+  - Query parameters passed to query from executed_statements.
+  returned: on succes
+  type: list
+  sample: [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -383,10 +385,14 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     connect_to_db_via_client,
     execute_query,
     get_main_conn_kwargs,
+    get_on_cluster_clause,
+    validate_identifier,
+    cluster_argument_spec,
 )
 from ansible_collections.community.clickhouse.plugins.module_utils.entity_settings import EntitySettings
 
 executed_statements = []
+query_parameters = []
 
 
 class ClickHouseUser():
@@ -394,6 +400,7 @@ class ClickHouseUser():
         self.changed = False
         self.module = module
         self.client = client
+        validate_identifier(module, name, "user name")
         self.name = name
         # Set default values, then update
         self.user_exists = False
@@ -411,9 +418,9 @@ class ClickHouseUser():
         # Collecting user information
         query = ("SELECT name, storage, auth_type, default_roles_list "
                  "FROM system.users "
-                 "WHERE name = '%s'" % self.name)
-
-        result = execute_query(self.module, self.client, query)
+                 "WHERE name = %(user)s")
+        execute_kwargs = {'params': {'user': self.name}}
+        result = execute_query(self.module, self.client, query, execute_kwargs)
 
         if result != []:
             self.user_exists = True
@@ -426,16 +433,18 @@ class ClickHouseUser():
 
     def __fetch_user_groups(self):
         query = ("SELECT granted_role_name FROM system.role_grants "
-                 "WHERE user_name = '%s'" % self.name)
-        result = execute_query(self.module, self.client, query)
+                 "WHERE user_name = %(user)s")
+        execute_kwargs = {'params': {'user': self.name}}
+        result = execute_query(self.module, self.client, query, execute_kwargs)
         return [row[0] for row in result]
 
     def __fetch_user_settings(self):
         """Fetch current user settings from system.settings_profile_elements"""
         query = ("SELECT setting_name, value, min, max, writability, inherit_profile "
                  "FROM system.settings_profile_elements "
-                 "WHERE user_name = '%s'" % self.name)
-        result = execute_query(self.module, self.client, query)
+                 "WHERE user_name = %(user)s")
+        execute_kwargs = {'params': {'user': self.name}}
+        result = execute_query(self.module, self.client, query, execute_kwargs)
 
         # Build a dict of current settings with their full definition
         settings_dict = {}
@@ -473,8 +482,9 @@ class ClickHouseUser():
     def __fetch_user_hosts(self):
         """Fetch current user host restrictions from system.users"""
         query = ("SELECT host_ip, host_names, host_names_regexp, host_names_like FROM system.users "
-                 "WHERE name = '%s'" % self.name)
-        result = execute_query(self.module, self.client, query)
+                 "WHERE name = %(user)s")
+        execute_kwargs = {'params': {'user': self.name}}
+        result = execute_query(self.module, self.client, query, execute_kwargs)
 
         user_hosts_dict = {
             'IP': set(result[0][0]),       # HOST ANY is represented by ['::/0'] in host_ip
@@ -488,9 +498,9 @@ class ClickHouseUser():
     def create(self, type_password, password, cluster, user_hosts, settings,
                roles, roles_mode, default_roles, default_roles_mode, authentication, profiles):
 
-        query = "CREATE USER '%s'" % self.name
+        query = "CREATE USER `%s`" % self.name
 
-        ident_clause = self._build_identified_clause(
+        ident_clause, password_param = self._build_identified_clause(
             auth=authentication,
             legacy_type_password=type_password,
             legacy_password=password,
@@ -500,8 +510,7 @@ class ClickHouseUser():
         if user_hosts:
             query += " %s" % self.__build_user_host_clause(user_hosts)
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query += get_on_cluster_clause(self.module, cluster)
 
         if settings or profiles:
             if isinstance(settings, list):
@@ -521,10 +530,15 @@ class ClickHouseUser():
             else:
                 self.module.fail_json(msg=f"Unexpexted settings passed: {settings}. Supported list or dict.")
 
-        executed_statements.append(query)
+        if password_param:
+            execute_kwargs = {"params": password_param}
+            query_parameters.append(password_param)
+        else:
+            execute_kwargs = {}
 
+        executed_statements.append(query)
         if not self.module.check_mode:
-            execute_query(self.module, self.client, query)
+            execute_query(self.module, self.client, query, execute_kwargs)
 
         if roles and roles_mode != 'remove':
             self.__grant_roles(roles, cluster)
@@ -554,9 +568,8 @@ class ClickHouseUser():
         return self.changed
 
     def drop(self, cluster):
-        query = "DROP USER '%s'" % self.name
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query = "DROP USER `%s`" % self.name
+        query += get_on_cluster_clause(self.module, cluster)
 
         executed_statements.append(query)
 
@@ -608,7 +621,7 @@ class ClickHouseUser():
 
         elif mode == 'listed_only':
             if desired_def_roles == [] and self.current_roles:
-                self.__unset_default_roles()
+                self.__unset_default_roles(cluster)
 
             elif desired_def_roles != [] and des != cur:
                 self.__set_default_roles(desired_def_roles, cluster)
@@ -621,23 +634,26 @@ class ClickHouseUser():
         # TODO: When ClickHouse will allow to retrieve password hashes,
         # make this idempotent, i.e. execute this only if the passwords don't match
 
-        query = "ALTER USER '%s'" % self.name
+        query = "ALTER USER `%s`" % self.name
+        query += get_on_cluster_clause(self.module, cluster)
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
-
-        ident_clause = self._build_identified_clause(
+        ident_clause, password_param = self._build_identified_clause(
             auth=authentication,
             legacy_type_password=type_pwd,
             legacy_password=pwd,
         )
 
         query += "%s" % ident_clause
-
         executed_statements.append(query)
 
+        if password_param:
+            execute_kwargs = {"params": password_param}
+            query_parameters.append(password_param)
+        else:
+            execute_kwargs = {}
+
         if not self.module.check_mode:
-            execute_query(self.module, self.client, query)
+            execute_query(self.module, self.client, query, execute_kwargs)
 
         self.changed = True
 
@@ -648,10 +664,9 @@ class ClickHouseUser():
         if des == cur:
             return
 
-        query = "ALTER USER '%s' %s" % (self.name, self.__build_user_host_clause(user_hosts))
+        query = "ALTER USER `%s` %s" % (self.name, self.__build_user_host_clause(user_hosts))
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query += get_on_cluster_clause(self.module, cluster)
 
         executed_statements.append(query)
 
@@ -703,11 +718,11 @@ class ClickHouseUser():
         return ' '.join(clauses)
 
     def __grant_roles(self, roles_to_set, cluster):
-        query = "GRANT %s TO '%s'" % (', '.join(roles_to_set), self.name)
+        prepared_roles_to_revoke = self.__quote_elements_in_list(roles_to_set)
+        query = "GRANT %s TO `%s`" % (', '.join(prepared_roles_to_revoke), self.name)
         executed_statements.append(query)
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query += get_on_cluster_clause(self.module, cluster)
 
         if not self.module.check_mode:
             execute_query(self.module, self.client, query)
@@ -715,11 +730,11 @@ class ClickHouseUser():
         self.changed = True
 
     def __revoke_roles(self, roles_to_revoke, cluster):
-        query = "REVOKE %s FROM '%s'" % (', '.join(roles_to_revoke), self.name)
+        prepared_roles_to_revoke = self.__quote_elements_in_list(roles_to_revoke)
+        query = "REVOKE %s FROM `%s`" % (', '.join(prepared_roles_to_revoke), self.name)
         executed_statements.append(query)
 
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        query += get_on_cluster_clause(self.module, cluster)
 
         if not self.module.check_mode:
             execute_query(self.module, self.client, query)
@@ -731,10 +746,9 @@ class ClickHouseUser():
         for role in roles_to_set:
             if role not in self.current_roles and role not in self.module.params["roles"]:
                 self.module.fail_json("User %s is not in %s role. Grant it explicitly first." % (self.name, role))
-
-        query = "ALTER USER '%s' DEFAULT ROLE %s" % (self.name, ', '.join(roles_to_set))
-        if cluster:
-            query += " ON CLUSTER %s" % cluster
+        prepared_roles_to_set = self.__quote_elements_in_list(roles_to_set)
+        query = "ALTER USER `%s` DEFAULT ROLE %s" % (self.name, ', '.join(prepared_roles_to_set))
+        query += get_on_cluster_clause(self.module, cluster)
         executed_statements.append(query)
 
         if not self.module.check_mode:
@@ -742,8 +756,10 @@ class ClickHouseUser():
 
         self.changed = True
 
-    def __unset_default_roles(self):
-        query = "SET DEFAULT ROLE NONE TO '%s'" % self.name
+    def __unset_default_roles(self, cluster):
+        query = "ALTER USER `%s`" % self.name
+        query += get_on_cluster_clause(self.module, cluster)
+        query += " DEFAULT ROLE NONE"
         executed_statements.append(query)
 
         if not self.module.check_mode:
@@ -806,7 +822,7 @@ class ClickHouseUser():
                 return
 
             # Build the ALTER USER query
-            query = "ALTER USER '%s' SETTINGS" % self.name
+            query = "ALTER USER `%s` SETTINGS" % self.name
             for index, value in enumerate(settings):
                 query += " %s" % value
                 if index < len(settings) - 1:
@@ -815,13 +831,12 @@ class ClickHouseUser():
             if cluster:
                 query += " ON CLUSTER %s" % cluster
         elif isinstance(settings, dict) or profiles:
-            query = "ALTER USER '%s'" % self.name
+            query = "ALTER USER `%s`" % self.name
             changed, settings_entity, changes = self.settings.compare_and_build_clause(settings, profiles)
             if not changed:
                 return
             query += settings_entity
-            if cluster:
-                query += " ON CLUSTER %s" % cluster
+            query += get_on_cluster_clause(self.module, cluster)
         else:
             return
         executed_statements.append(query)
@@ -836,34 +851,39 @@ class ClickHouseUser():
             atype = auth.get('type', '').lower().strip()
 
             if atype == "not_identified":
-                return " NOT IDENTIFIED"
+                return " NOT IDENTIFIED", None
 
             if atype == 'no_password':
-                return " IDENTIFIED WITH NO_PASSWORD"
+                return " IDENTIFIED WITH NO_PASSWORD", None
 
             if atype == 'ldap':
                 server = auth.get('server')
                 if not server:
                     self.module.fail_json(msg="authentication.type=ldap requires 'server'")
-                return f" IDENTIFIED WITH ldap SERVER '{server}'"
+                return " IDENTIFIED WITH ldap SERVER %(server)s", {'server': server}
 
             password = auth.get('password') or legacy_password
             if password is None:
                 self.module.fail_json(msg=f"type {atype} requires password")
+            pass_param = {'password': password}
 
             if atype in ('plaintext_password', 'sha256_password', 'double_sha1_password', 'bcrypt_password'):
-                return f" IDENTIFIED WITH {atype} BY '{password}'"
+                return f" IDENTIFIED WITH {atype} BY %(password)s", pass_param
 
             # Separate so maybe in future add salt here.
             if atype in ('sha256_hash', 'double_sha1_hash', 'bcrypt_hash'):
-                return f" IDENTIFIED WITH {atype} BY '{password}'"
+                return f" IDENTIFIED WITH {atype} BY %(password)s", pass_param
 
             self.module.fail_json(msg=f"type {atype} not implemented")
 
         # Backward compatibility
         if legacy_password is not None:
-            return f" IDENTIFIED WITH {legacy_type_password} BY '{legacy_password}'"
-        return ""
+            return f" IDENTIFIED WITH {legacy_type_password} BY '{legacy_password}'", None
+        return "", None
+
+    def __quote_elements_in_list(self, src):
+        '''Prepare elements for query. Closed in backticks.'''
+        return [f"`{i}`" for i in src]
 
 
 def main():
@@ -909,7 +929,6 @@ def main():
                 password=dict(type='str', no_log=True),
             ),
         ),
-        cluster=dict(type='str', default=None),
         update_password=dict(
             type='str', choices=['always', 'on_create'],
             default='on_create', no_log=False
@@ -924,7 +943,7 @@ def main():
         default_roles_mode=dict(type='str', choices=['listed_only', 'append', 'remove'],
                                 default='listed_only')
     )
-
+    argument_spec.update(cluster_argument_spec())
     # Instantiate an object of module class
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -980,7 +999,7 @@ def main():
     client.disconnect_connection()
 
     # Users will get this in JSON output after execution
-    module.exit_json(changed=changed, executed_statements=executed_statements)
+    module.exit_json(changed=changed, executed_statements=executed_statements, query_parameters=query_parameters)
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/clickhouse_user/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_user/tasks/initial.yml
@@ -18,7 +18,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH sha256_password BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH sha256_password BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -95,7 +97,7 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' NOT IDENTIFIED"]
+        - result.executed_statements == ["CREATE USER `test_user` NOT IDENTIFIED"]
 
     - name: Check the actual state
       register: result
@@ -171,7 +173,7 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH NO_PASSWORD"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH NO_PASSWORD"]
 
     - name: Check the actual state
       register: result
@@ -248,7 +250,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH sha256_password BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH sha256_password BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -327,7 +331,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH sha256_hash BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH sha256_hash BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -406,7 +412,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH double_sha1_password BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH double_sha1_password BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -485,7 +493,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH double_sha1_hash BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH double_sha1_hash BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -564,7 +574,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH bcrypt_password BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH bcrypt_password BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -643,7 +655,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH bcrypt_hash BY '********'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH bcrypt_hash BY %(password)s"]
+        - >
+          result.query_parameters == [{"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"}]
 
     - name: Check the actual state
       register: result
@@ -660,14 +674,14 @@
         - result is not changed
         - result["users"]["test_user"] is not defined
 
-    - name: Create test_user with authentication bcrypt password in real mode
+    - name: Create test_user with authentication bcrypt hash in real mode
       register: result
       community.clickhouse.clickhouse_user:
         state: present
         name: test_user
         authentication:
           type: bcrypt_hash
-          password: $2a$12$4fjXRdyPxLWNiZ2fAWTsIezG87Nzb0oyr7BZlNqm2p4HtfyvNsff2\0\0\0\0
+          password: $2a$12$4fjXRdyPxLWNiZ2fAWTsIezG87Nzb0oyr7BZlNqm2p4HtfyvNsff2
 
     - name: Check the actual state
       register: result
@@ -694,7 +708,7 @@
         name: test_user
         authentication:
           type: bcrypt_hash
-          password: $2a$12$4fjXRdyPxLWNiZ2fAWTsIezG87Nzb0oyr7BZlNqm2p4HtfyvNsff2\0\0\0\0
+          password: $2a$12$4fjXRdyPxLWNiZ2fAWTsIezG87Nzb0oyr7BZlNqm2p4HtfyvNsff2
 
     - name: Check result
       ansible.builtin.assert:
@@ -722,7 +736,9 @@
       ansible.builtin.assert:
         that:
         - result is changed
-        - result.executed_statements == ["CREATE USER 'test_user' IDENTIFIED WITH ldap SERVER 'ad'"]
+        - result.executed_statements == ["CREATE USER `test_user` IDENTIFIED WITH ldap SERVER %(server)s"]
+        - >
+          result.query_parameters == [{'server': 'ad'}]
 
     - name: Check the actual state
       register: result
@@ -880,7 +896,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER USER 'test_user' IDENTIFIED WITH sha256_password BY '********'"]
+    - result.executed_statements == ["ALTER USER `test_user` IDENTIFIED WITH sha256_password BY '********'"]
+    - result.query_parameters == []
+
 
 - name: Drop test_user
   community.clickhouse.clickhouse_user:
@@ -916,7 +934,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "ALTER USER 'test_user' SETTINGS max_memory_usage = 20000 READONLY"
+    - result.executed_statements[0] == "ALTER USER `test_user` SETTINGS max_memory_usage = 20000 READONLY"
 
 - name: Update user settings in real mode
   register: result
@@ -930,7 +948,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "ALTER USER 'test_user' SETTINGS max_memory_usage = 20000 READONLY"
+    - result.executed_statements[0] == "ALTER USER `test_user` SETTINGS max_memory_usage = 20000 READONLY"
 
 - name: Verify settings in database using clickhouse_client
   register: result
@@ -988,7 +1006,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "ALTER USER 'test_user' SETTINGS max_memory_usage = 25000 READONLY, max_threads = 8, PROFILE 'readonly'"
+    - result.executed_statements[0] == "ALTER USER `test_user` SETTINGS max_memory_usage = 25000 READONLY, max_threads = 8, PROFILE 'readonly'"
 
 - name: Verify multiple settings in database using clickhouse_client
   register: result
@@ -1032,8 +1050,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant, manager TO 'test_user'" or result.executed_statements[0] == "GRANT manager, accountant TO 'test_user'"
-    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE manager, accountant"
+    - result.executed_statements[0] == "GRANT `accountant`, `manager` TO `test_user`" or result.executed_statements[0] == "GRANT `manager`, `accountant` TO `test_user`"
+    - result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `accountant`, `manager`" or result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `manager`, `accountant`"
 
 - name: Check the actual state
   register: result
@@ -1065,8 +1083,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant, manager TO 'test_user'" or result.executed_statements[0] == "GRANT manager, accountant TO 'test_user'"
-    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant, manager" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE manager, accountant"
+    - result.executed_statements[0] == "GRANT `accountant`, `manager` TO `test_user`" or result.executed_statements[0] == "GRANT `manager`, `accountant` TO `test_user`"
+    - result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `accountant`, `manager`" or result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `manager`, `accountant`"
 
 - name: Check the actual state
   register: result
@@ -1097,9 +1115,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT sales TO 'test_user'"
-    - result.executed_statements[1] == "REVOKE accountant, manager FROM 'test_user'" or result.executed_statements[1] == "REVOKE manager, accountant FROM 'test_user'"
-    - result.executed_statements[2] == "ALTER USER 'test_user' DEFAULT ROLE sales"
+    - result.executed_statements[0] == "GRANT `sales` TO `test_user`"
+    - result.executed_statements[1] == "REVOKE `accountant`, `manager` FROM `test_user`" or result.executed_statements[1] == "REVOKE `manager`, `accountant` FROM `test_user`"
+    - result.executed_statements[2] == "ALTER USER `test_user` DEFAULT ROLE `sales`"
 
 - name: Check the actual state
   register: result
@@ -1127,9 +1145,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT sales TO 'test_user'"
-    - result.executed_statements[1] == "REVOKE accountant, manager FROM 'test_user'" or result.executed_statements[1] == "REVOKE manager, accountant FROM 'test_user'"
-    - result.executed_statements[2] == "ALTER USER 'test_user' DEFAULT ROLE sales"
+    - result.executed_statements[0] == "GRANT `sales` TO `test_user`"
+    - result.executed_statements[1] == "REVOKE `accountant`, `manager` FROM `test_user`" or result.executed_statements[1] == "REVOKE `manager`, `accountant` FROM `test_user`"
+    - result.executed_statements[2] == "ALTER USER `test_user` DEFAULT ROLE `sales`"
 
 - name: Check the actual state
   register: result
@@ -1194,8 +1212,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "GRANT accountant TO 'test_user'"
-    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE sales, accountant" or result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant, sales"
+    - result.executed_statements[0] == "GRANT `accountant` TO `test_user`"
+    - result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `sales`, `accountant`" or result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `accountant`, `sales`"
 
 - name: Check the actual state
   register: result
@@ -1223,7 +1241,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO 'test_user'"
+    - result.executed_statements[0] == "ALTER USER `test_user` DEFAULT ROLE NONE"
 
 - name: Check the actual state
   register: result
@@ -1250,7 +1268,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "SET DEFAULT ROLE NONE TO 'test_user'"
+    - result.executed_statements[0] == "ALTER USER `test_user` DEFAULT ROLE NONE"
 
 - name: Check the actual state
   register: result
@@ -1278,7 +1296,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE accountant, sales FROM 'test_user'" or result.executed_statements[0] == "REVOKE sales, accountant FROM 'test_user'"
+    - result.executed_statements[0] == "REVOKE `accountant`, `sales` FROM `test_user`" or result.executed_statements[0] == "REVOKE `sales`, `accountant` FROM `test_user`"
 
 - name: Check the actual state
   register: result
@@ -1305,7 +1323,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE accountant, sales FROM 'test_user'" or result.executed_statements[0] == "REVOKE sales, accountant FROM 'test_user'"
+    - result.executed_statements[0] == "REVOKE `accountant`, `sales` FROM `test_user`" or result.executed_statements[0] == "REVOKE `sales`, `accountant` FROM `test_user`"
 
 - name: Check the actual state
   register: result
@@ -1407,8 +1425,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE manager FROM 'test_user'"
-    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant"
+    - result.executed_statements[0] == "REVOKE `manager` FROM `test_user`"
+    - result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `accountant`"
 
 - name: Check the actual state
   register: result
@@ -1440,8 +1458,8 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "REVOKE manager FROM 'test_user'"
-    - result.executed_statements[1] == "ALTER USER 'test_user' DEFAULT ROLE accountant"
+    - result.executed_statements[0] == "REVOKE `manager` FROM `test_user`"
+    - result.executed_statements[1] == "ALTER USER `test_user` DEFAULT ROLE `accountant`"
 
 - name: Check the actual state
   register: result
@@ -1506,9 +1524,9 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements[0] == "CREATE USER 'test_user_1'"
-    - result.executed_statements[1] == "GRANT test_listed_only TO 'test_user_1'"
-    - result.executed_statements[2] == "ALTER USER 'test_user_1' DEFAULT ROLE test_listed_only"
+    - result.executed_statements[0] == "CREATE USER `test_user_1`"
+    - result.executed_statements[1] == "GRANT `test_listed_only` TO `test_user_1`"
+    - result.executed_statements[2] == "ALTER USER `test_user_1` DEFAULT ROLE `test_listed_only`"
 
 - name: Check the actual state
   register: result
@@ -1654,7 +1672,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST NAME 'host1', 'host2'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST NAME 'host1', 'host2'"]
 
 - name: Check the actual state
   register: result
@@ -1684,7 +1702,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST NAME 'host1', 'host2'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST NAME 'host1', 'host2'"]
 
 - name: Check the actual state
   register: result
@@ -1778,7 +1796,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["ALTER USER 'test_user' HOST ANY"]
+      - result.executed_statements == ["ALTER USER `test_user` HOST ANY"]
 
 - name: Check the actual state
   register: result
@@ -1865,7 +1883,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["ALTER USER 'test_user' HOST NAME 'host3'"]
+      - result.executed_statements == ["ALTER USER `test_user` HOST NAME 'host3'"]
 
 - name: Update user host restrictions in real mode
   register: result
@@ -1881,7 +1899,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["ALTER USER 'test_user' HOST NAME 'host3'"]
+      - result.executed_statements == ["ALTER USER `test_user` HOST NAME 'host3'"]
 
 - name: Check the actual state
   register: result
@@ -1911,7 +1929,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["ALTER USER 'test_user' HOST LIKE '%.mysite.com'"]
+      - result.executed_statements == ["ALTER USER `test_user` HOST LIKE '%.mysite.com'"]
 
 - name: Update user host restrictions to another host_type in real mode (should replace previous host restrictions)
   register: result
@@ -1927,7 +1945,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["ALTER USER 'test_user' HOST LIKE '%.mysite.com'"]
+      - result.executed_statements == ["ALTER USER `test_user` HOST LIKE '%.mysite.com'"]
 
 - name: Check the actual state
   register: result
@@ -1972,7 +1990,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST LIKE '%.mysite1.com' HOST REGEXP '.*\\.mysite2\\.com' HOST NAME 'hostA' HOST IP '192.168.0.0/16'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST LIKE '%.mysite1.com' HOST REGEXP '.*\\.mysite2\\.com' HOST NAME 'hostA' HOST IP '192.168.0.0/16'"]
 
 - name: Create test_user with multiple host restriction types in real mode
   community.clickhouse.clickhouse_user:
@@ -1996,7 +2014,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST LIKE '%.mysite1.com' HOST REGEXP '.*\\.mysite2\\.com' HOST NAME 'hostA' HOST IP '192.168.0.0/16'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST LIKE '%.mysite1.com' HOST REGEXP '.*\\.mysite2\\.com' HOST NAME 'hostA' HOST IP '192.168.0.0/16'"]
 
 - name: Check the actual state
   register: result
@@ -2032,7 +2050,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST LOCAL"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST LOCAL"]
 
 - name: Create test_user with type hosts that don't require hosts in real mode
   register: result
@@ -2046,7 +2064,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST LOCAL"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST LOCAL"]
 
 - name: Check the actual state
   register: result
@@ -2082,7 +2100,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST NAME 'host-name', 'host.name'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST NAME 'host-name', 'host.name'"]
 
 - name: Create test_user with hosts containing special characters in real mode
   register: result
@@ -2099,7 +2117,7 @@
   ansible.builtin.assert:
     that:
       - result is changed
-      - result.executed_statements == ["CREATE USER 'test_user' HOST NAME 'host-name', 'host.name'"]
+      - result.executed_statements == ["CREATE USER `test_user` HOST NAME 'host-name', 'host.name'"]
 
 - name: Check the actual state
   register: result
@@ -2160,7 +2178,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE USER 'test_user' SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
+    - result.executed_statements == ["CREATE USER `test_user` SETTINGS max_memory_usage='15000' CONST, max_memory_usage_for_all_queries='15000' MIN '15000' MAX '16000' WRITABLE"]
 
 - name: Check user has settings
   register: result
@@ -2215,7 +2233,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER USER 'test_user' SETTINGS PROFILE 'web'"]
+    - result.executed_statements == ["ALTER USER `test_user` SETTINGS PROFILE 'web'"]
 
 - name: Alter user removing settings with settings as dictionary - workaround 
   register: result
@@ -2228,7 +2246,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER USER 'test_user' SETTINGS NONE"]
+    - result.executed_statements == ["ALTER USER `test_user` SETTINGS NONE"]
 
 - name: Alter user removing settings with settings as dictionary - idempotency
   register: result
@@ -2259,7 +2277,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE USER 'test_user' ON CLUSTER default"]
+    - result.executed_statements == ["CREATE USER `test_user` ON CLUSTER `default`"]
 
 - name: Test 14 - Alter user on cluster
   register: result
@@ -2276,7 +2294,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["ALTER USER 'test_user' SETTINGS max_memory_usage='15000' CONST ON CLUSTER default"]
+    - result.executed_statements == ["ALTER USER `test_user` SETTINGS max_memory_usage='15000' CONST ON CLUSTER `default`"]
 
 - name: Test 14 - Drop user on cluster
   register: result
@@ -2289,7 +2307,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["DROP USER 'test_user' ON CLUSTER default"]
+    - result.executed_statements == ["DROP USER `test_user` ON CLUSTER `default`"]
 
 - name: Drop test_role
   community.clickhouse.clickhouse_role:

--- a/tests/unit/plugins/modules/test_clickhouse_user.py
+++ b/tests/unit/plugins/modules/test_clickhouse_user.py
@@ -45,21 +45,39 @@ def test_user_not_exists(user):
     assert user.user_exists is False
 
 
+@pytest.mark.parametrize(
+    "auth,leg_type,leg_pass,expected,param",
+    [
+        (None, 'sha256_password', 'test_pass', " IDENTIFIED WITH sha256_password BY 'test_pass'", None),
+        ({'type': 'sha256_password', 'password': 'test_pass'}, None, None, " IDENTIFIED WITH sha256_password BY %(password)s", {'password': 'test_pass'}),
+        ({'type': 'sha256_hash', 'password': 'test_hash'}, None, None, " IDENTIFIED WITH sha256_hash BY %(password)s", {'password': 'test_hash'}),
+        ({'type': 'not_identified'}, None, None, " NOT IDENTIFIED", None),
+        ({'type': 'no_password'}, None, None, " IDENTIFIED WITH NO_PASSWORD", None),
+        ({'type': 'ldap', 'server': 'ad'}, None, None, " IDENTIFIED WITH ldap SERVER %(server)s", {'server': 'ad'}),
+    ]
+)
+def test_build_ident_clause_correct(user, auth, leg_type, leg_pass, expected, param):
+    result, result_param = user._build_identified_clause(auth, leg_type, leg_pass)
+
+    user.module.fail_json.assert_not_called()
+    assert result == expected
+    assert param == result_param
+
+
+@pytest.mark.parametrize("auth", [{'type': 'ldap'},])
+def test_build_ident_clause_incorrect(user, auth):
+    user._build_identified_clause(auth)
+
+    user.module.fail_json.assert_called_once()
+
+
 def test_create_ldap_user(user, mock_execute):
     user.create(
         None, None, None, None, None, None,
         'listed_only', None, 'listed_only',
         {'type': 'ldap', 'server': 'ad'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH ldap SERVER 'ad'"
-
-
-def test_create_ldap_user_without_server(user, mock_execute):
-    user.create(
-        None, None, None, None, None, None,
-        'listed_only', None, 'listed_only',
-        {'type': 'ldap'}, [])
-    user.module.fail_json.assert_called_once()
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH ldap SERVER %(server)s"
 
 
 def test_create_sha256_pass_user(user, mock_execute):
@@ -68,7 +86,7 @@ def test_create_sha256_pass_user(user, mock_execute):
         'listed_only', None, 'listed_only',
         {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s"
 
 
 def test_create_sha256_hash_user(user, mock_execute):
@@ -79,7 +97,7 @@ def test_create_sha256_hash_user(user, mock_execute):
         []
     )
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_hash BY '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_hash BY %(password)s"
 
 
 def test_create_sha256_hash_user_old_way(user, mock_execute):
@@ -88,7 +106,7 @@ def test_create_sha256_hash_user_old_way(user, mock_execute):
         None, [], None, None, 'listed_only',
         None, 'listed_only', None, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_hash BY '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_hash BY '0b14d501a594442a01c6859541bcb3e8164d183d32937b851835442f69d5c94e'"
 
 
 def test_create_sha256_pass_user_old_way(user, mock_execute):
@@ -97,7 +115,7 @@ def test_create_sha256_pass_user_old_way(user, mock_execute):
         None, None, None, None,
         'listed_only', None, 'listed_only', None, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY 'password1'"
 
 
 def test_create_not_identified_user(user, mock_execute):
@@ -106,7 +124,7 @@ def test_create_not_identified_user(user, mock_execute):
         'listed_only', None, 'listed_only',
         {'type': 'not_identified'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' NOT IDENTIFIED"
+    assert actual_query == "CREATE USER `alice` NOT IDENTIFIED"
 
 
 def test_create_no_password_user(user, mock_execute):
@@ -115,7 +133,7 @@ def test_create_no_password_user(user, mock_execute):
         'listed_only', None, 'listed_only',
         {'type': 'no_password'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH NO_PASSWORD"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH NO_PASSWORD"
 
 
 def test_create_user_with_settings(user, mock_execute):
@@ -125,7 +143,7 @@ def test_create_user_with_settings(user, mock_execute):
         None, 'listed_only', None, 'listed_only',
         {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' SETTINGS max_concurrent_queries=3, max_threads=8"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s SETTINGS max_concurrent_queries=3, max_threads=8"
 
 
 def test_create_user_with_host_name_passed(user, mock_execute):
@@ -136,7 +154,7 @@ def test_create_user_with_host_name_passed(user, mock_execute):
         None, 'listed_only',
         {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST NAME 'host1'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s HOST NAME 'host1'"
 
 
 def test_create_user_with_host_ip_passed(user, mock_execute):
@@ -147,7 +165,7 @@ def test_create_user_with_host_ip_passed(user, mock_execute):
         'listed_only', None, 'listed_only',
         {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '127.0.0.1'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s HOST IP '127.0.0.1'"
 
 
 def test_create_user_with_host_cidr_passed(user, mock_execute):
@@ -158,7 +176,7 @@ def test_create_user_with_host_cidr_passed(user, mock_execute):
         'listed_only', None,
         'listed_only', {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '10.0.0.0/8'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s HOST IP '10.0.0.0/8'"
 
 
 def test_create_user_with_host_complex_passed(user, mock_execute):
@@ -169,7 +187,7 @@ def test_create_user_with_host_complex_passed(user, mock_execute):
         'listed_only', None, 'listed_only',
         {'type': 'sha256_password', 'password': 'password1'}, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' IDENTIFIED WITH sha256_password BY 'password1' HOST IP '10.0.0.0/8' HOST NAME 'host1'"
+    assert actual_query == "CREATE USER `alice` IDENTIFIED WITH sha256_password BY %(password)s HOST IP '10.0.0.0/8' HOST NAME 'host1'"
 
 
 def test_create_user_using_dict_settings(user, mock_execute):
@@ -179,7 +197,7 @@ def test_create_user_using_dict_settings(user, mock_execute):
         'listed_only', None, 'listed_only',
         None, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' SETTINGS max_memory_usage='10G'"
+    assert actual_query == "CREATE USER `alice` SETTINGS max_memory_usage='10G'"
 
 
 def test_create_user_using_profiles_prameter(user, mock_execute):
@@ -189,7 +207,7 @@ def test_create_user_using_profiles_prameter(user, mock_execute):
         'listed_only', None, 'listed_only',
         None, ['app', 'web'])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' SETTINGS PROFILE 'app', PROFILE 'web'"
+    assert actual_query == "CREATE USER `alice` SETTINGS PROFILE 'app', PROFILE 'web'"
 
 
 def test_create_user_using_profiles_parameter_and_settings(user, mock_execute):
@@ -199,7 +217,7 @@ def test_create_user_using_profiles_parameter_and_settings(user, mock_execute):
         'listed_only', None, 'listed_only',
         None, ['app', 'web'])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER 'alice' SETTINGS PROFILE 'app', PROFILE 'web', max_memory_usage='10G'"
+    assert actual_query == "CREATE USER `alice` SETTINGS PROFILE 'app', PROFILE 'web', max_memory_usage='10G'"
 
 
 def test_create_user_using_profiles_parameter_and_settings_complex(user, mock_execute):
@@ -214,7 +232,7 @@ def test_create_user_using_profiles_parameter_and_settings_complex(user, mock_ex
     )
     actual_query = get_executed_query(mock_execute)
     assert actual_query == (
-        "CREATE USER 'alice' SETTINGS PROFILE 'app', "
+        "CREATE USER `alice` SETTINGS PROFILE 'app', "
         "PROFILE 'web', PROFILE 'test_profile', "
         "PROFILE 'web2', "
         "max_memory_usage='10G' MIN '1G' MAX '100G' CONST, "
@@ -242,7 +260,7 @@ def test_alter_user_profile_added(user_exist, mock_execute):
     )
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER USER 'alice' SETTINGS PROFILE 'web'"
+    assert actual_query == "ALTER USER `alice` SETTINGS PROFILE 'web'"
 
 
 def test_alter_user_setting_added(user_exist, mock_execute):
@@ -255,7 +273,7 @@ def test_alter_user_setting_added(user_exist, mock_execute):
     actual_query = get_executed_query(mock_execute)
     assert changed is True
     assert actual_query == (
-        "ALTER USER 'alice' SETTINGS "
+        "ALTER USER `alice` SETTINGS "
         "max_memory_usage='10G' MIN '1G' MAX '100G' CONST")
 
 
@@ -268,7 +286,7 @@ def test_alter_user_old_setting_added(user_exist, mock_execute):
     )
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER USER 'alice' SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST"
+    assert actual_query == "ALTER USER `alice` SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST"
 
 
 def test_alter_user_old_setting_with_profile_added(user_exist, mock_execute):
@@ -280,11 +298,11 @@ def test_alter_user_old_setting_with_profile_added(user_exist, mock_execute):
     )
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER USER 'alice' SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST, PROFILE web"
+    assert actual_query == "ALTER USER `alice` SETTINGS max_memory_usage='10G' MIN = '1G' MAX = '100G' CONST, PROFILE web"
 
 
 def test_drop(user_exist, mock_execute):
     changed = user_exist.drop(None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "DROP USER 'alice'"
+    assert actual_query == "DROP USER `alice`"


### PR DESCRIPTION
##### SUMMARY
Close role/user names in backticks to handle properly special characters. Inherit cluster spec option and documentation.
Pass password to clickhouse as query parameter.
Add query_parameters on return containing password or server(ldap auth).

##### ISSUE TYPE
- Chore

##### COMPONENT NAME
- clickhouse_user
