### PR TITLE
chore: update dependencies matrix

### DIFF
--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -24,11 +24,16 @@ jobs:
     strategy:
       matrix:
         ansible:
+          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
           - stable-2.21
           - devel
+        include:
+        - python: "3.13"
+        - ansible: stable-2.17
+          python: "3.12"
     steps:
 
       - name: Check out code
@@ -39,13 +44,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python}}
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color
+        run: ansible-test sanity --docker -v --color --python ${{ matrix.python }}
         working-directory: ./ansible_collections/community/clickhouse
 
   units:
@@ -57,11 +62,16 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
+          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
           - stable-2.21
           - devel
+        include:
+        - python: "3.13"
+        - ansible: stable-2.17
+          python: "3.12"
 
     steps:
       - name: Check out code
@@ -72,7 +82,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python}}
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -82,7 +92,7 @@ jobs:
 
       # Run the unit tests
       - name: Run unit test
-        run: ansible-test units -v --color --python 3.10 --docker --coverage
+        run: ansible-test units -v --color --python ${{ matrix.python }} --docker --coverage
         working-directory: ./ansible_collections/community/clickhouse
 
       # ansible-test support producing code coverage date
@@ -124,7 +134,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python}}
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check

--- a/.github/workflows/ansible-test-plugins.yml
+++ b/.github/workflows/ansible-test-plugins.yml
@@ -24,10 +24,10 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
     steps:
 
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -57,10 +57,10 @@ jobs:
       fail-fast: true
       matrix:
         ansible:
-          - stable-2.17
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
 
     steps:
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -105,6 +105,7 @@ jobs:
           - stable-2.18
           - stable-2.19
           - stable-2.20
+          - stable-2.21
           - devel
         clickhouse:
           - 24.8.14.39
@@ -112,7 +113,7 @@ jobs:
           - 25.8.22.28
           - 26.3.9.8
         python:
-          - "3.12"
+          - "3.13"
     steps:
 
       - name: Check out code
@@ -123,7 +124,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install ansible-base (${{ matrix.ansible }})
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
@@ -132,7 +133,7 @@ jobs:
         run: "sed -i 's/^clickhouse_version:.*/clickhouse_version: \"${{ matrix.clickhouse }}\"/g' ${{ env.clickhouse_version_file }}"
 
       - name: Run integration tests
-        run: ansible-test integration --docker ubuntu2404 -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
+        run: ansible-test integration --docker -v --color --retry-on-error --continue-on-error --python ${{ matrix.python }} --diff --coverage
         working-directory: ./ansible_collections/community/clickhouse
 
       - name: Generate coverage report.

--- a/changelogs/fragments/223-drop-2-17-core-support.yml
+++ b/changelogs/fragments/223-drop-2-17-core-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - remove support for ansible-core-2.17 and add for 2.21.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.17.0'
+requires_ansible: '>=2.18.0'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.18.0'
+requires_ansible: '>=2.17.0'


### PR DESCRIPTION
##### SUMMARY
CI started to fail.
Remove EOL 2.17 ansible core and add 2.21.
Change python to 3.13(supported by 2.18 core).
