### PR TITLE
feat(settings): normalize byte values

### DIFF
--- a/changelogs/fragments/normalize-data-size-in-settings.yml
+++ b/changelogs/fragments/normalize-data-size-in-settings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - settings - convert data size short formats to bytes. It makes system settings, user and role module idempotent when passing values like Gi, G etc.

--- a/plugins/module_utils/clickhouse.py
+++ b/plugins/module_utils/clickhouse.py
@@ -25,6 +25,7 @@ except ImportError:
     HAS_DB_DRIVER = False
 
 VALID_IDENTIFIER_PATTERN = re.compile(r'^[^`\\]+$')
+POSSIBLE_SIZE_PATTERN = re.compile(r'^([\d]+)(K|M|G|T|Ki|Mi|Gi|Ti)$')
 
 
 def client_common_argument_spec():
@@ -189,3 +190,19 @@ def normalize_db_table(module, client, database, table):
     else:
         validate_identifier(module, table)
     return f"`{database}`.`{table}`"
+
+
+def to_bytes_data(value):
+    units = {
+        'Ki': 1024**1,
+        'Mi': 1024**2,
+        'Gi': 1024**3,
+        'Ti': 1024**4,
+        'K': 1000**1,
+        'M': 1000**2,
+        'G': 1000**3,
+        'T': 1000**4,
+    }
+    match = POSSIBLE_SIZE_PATTERN.match(value)
+
+    return int(match.group(1)) * units[match.group(2)]

--- a/plugins/module_utils/entity_settings.py
+++ b/plugins/module_utils/entity_settings.py
@@ -6,6 +6,8 @@ from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse import (
     execute_query,
+    to_bytes_data,
+    POSSIBLE_SIZE_PATTERN,
 )
 
 
@@ -163,8 +165,8 @@ class EntitySettings():
 
             # Convert numbers to strings (for all fields)
             for prop_name, prop_value in normalized_config.items():
-                if isinstance(prop_value, (int, float)):
-                    normalized_config[prop_name] = str(prop_value)
+                prop_value = self._normalize_value(prop_value)
+                normalized_config[prop_name] = prop_value
 
             # Writable uppercase and replace aliases
             if normalized_config.get('writability', ''):
@@ -177,3 +179,16 @@ class EntitySettings():
             normalized[setting_name] = normalized_config
 
         return normalized
+
+    def _normalize_value(self, value):
+        if value is None:
+            return None
+        if POSSIBLE_SIZE_PATTERN.match(str(value)):
+            return str(self._normalize_settings_value_bytes(value))
+        return str(value)
+
+    def _normalize_settings_value_bytes(self, value):
+        try:
+            return to_bytes_data(value)
+        except Exception:
+            self.module.fail_json(msg=f"Unexpected error. Failed normalizing bytes format {value}")

--- a/plugins/modules/clickhouse_settings_profile.py
+++ b/plugins/modules/clickhouse_settings_profile.py
@@ -23,11 +23,8 @@ attributes:
     description: Supports check_mode.
     support: full
   idempotent:
-    description:
-      - Module can't determine what data type is certain setting.
-        So when passing setting that will be resolved by server to another value module will be not idempotent.
-        For example passing 1G as value server will store this as 100000000.
-    support: partial
+    description: When run twice in a row outside check mode, with the same arguments, the second invocation indicates no change.
+    support: full
 
 author:
   - Rafal Kozlowski (@rkozlo)

--- a/tests/integration/targets/clickhouse_settings_profile/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_settings_profile/tasks/initial.yml
@@ -296,7 +296,7 @@
   ansible.builtin.assert:
     that:
       - result.changed == true
-      - result.executed_statements == ["CREATE SETTINGS PROFILE `test_profile` SETTINGS max_threads='1', enable_positional_arguments='0', max_memory_usage='10G'"]
+      - result.executed_statements == ["CREATE SETTINGS PROFILE `test_profile` SETTINGS max_threads='1', enable_positional_arguments='0', max_memory_usage='10000000000'"]
 
 - name: Create setting profile with settings - idempotency
   community.clickhouse.clickhouse_settings_profile:
@@ -309,6 +309,11 @@
       max_memory_usage:
         value: '10G'
   register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
 
 - name: Drop settings profile
   community.clickhouse.clickhouse_settings_profile:

--- a/tests/unit/plugins/module_utils/test_clickhouse.py
+++ b/tests/unit/plugins/module_utils/test_clickhouse.py
@@ -11,7 +11,8 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     client_common_argument_spec,
     get_main_conn_kwargs,
     validate_identifier,
-    normalize_db_table
+    normalize_db_table,
+    to_bytes_data,
 )
 
 REASON = "The clickhouse_driver module is not installed"
@@ -186,3 +187,26 @@ def test_validate_identifier_with_custom_context(mocker):
     mock_module.fail_json.assert_called_once()
     call_msg = mock_module.fail_json.call_args[1]['msg']
     assert "Invalid cluster name" in call_msg
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("1K", 1000),
+    ("128K", 128000),
+    ("1M", 1000000),
+    ("16M", 16000000),
+    ("1G", 1000000000),
+    ("31G", 31000000000),
+    ("1T", 1000000000000),
+    ("2T", 2000000000000),
+    ("1Ki", 1024),
+    ("128Ki", 131072),
+    ("1Mi", 1048576),
+    ("16Mi", 16777216),
+    ("1Gi", 1073741824),
+    ("31Gi", 33285996544),
+    ("1Ti", 1099511627776),
+    ("2Ti", 2199023255552),
+])
+def test_normalize_data_values(value, expected):
+    result = to_bytes_data(value)
+    assert result == expected

--- a/tests/unit/plugins/module_utils/test_entity_settings.py
+++ b/tests/unit/plugins/module_utils/test_entity_settings.py
@@ -264,6 +264,48 @@ def test_normalizing_passed_settings_quota_floats(user_ent):
     }
 
 
+def test_normalizing_passed_1000_based_data(user_ent):
+    result = user_ent._normalize_settings(
+        {
+            'max_memory_usage': {
+                'value': "1G",
+                'min': "200M",
+                'max': "2G",
+                'writability': 'CONST'
+            }
+        }
+    )
+    assert result == {
+        'max_memory_usage': {
+            'value': '1000000000',
+            'min': '200000000',
+            'max': '2000000000',
+            'writability': 'CONST'
+        }
+    }
+
+
+def test_normalizing_passed_1024_based_data(user_ent):
+    result = user_ent._normalize_settings(
+        {
+            'max_memory_usage': {
+                'value': "1Gi",
+                'min': "200Mi",
+                'max': "2Gi",
+                'writability': 'CONST'
+            }
+        }
+    )
+    assert result == {
+        'max_memory_usage': {
+            'value': '1073741824',
+            'min': '209715200',
+            'max': '2147483648',
+            'writability': 'CONST'
+        }
+    }
+
+
 def test_returning_entity_no_changes(user_ent):
     result = user_ent.compare_and_build_clause(
         {

--- a/tests/unit/plugins/modules/test_clickhouse_role.py
+++ b/tests/unit/plugins/modules/test_clickhouse_role.py
@@ -47,7 +47,7 @@ def test_alter_role_one_setting_new_setting(role, mock_execute, mocker):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10000000000'"
 
 
 def test_alter_role_one_profile_new_setting(role, mock_execute):
@@ -61,7 +61,7 @@ def test_alter_role_one_profile_one_setting_new_setting(role, mock_execute):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, ['web'], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE `test_role` SETTINGS PROFILE 'web', max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS PROFILE 'web', max_memory_usage='10000000000'"
 
 
 def test_drop(role, mock_execute):
@@ -102,4 +102,4 @@ def test_alter_role_add_settings_del_profile(role, mock_execute, mocker):
     changed = role.alter({'max_memory_usage': {'value': '10G'}}, [], None)
     actual_query = get_executed_query(mock_execute)
     assert changed is True
-    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10G'"
+    assert actual_query == "ALTER ROLE `test_role` SETTINGS max_memory_usage='10000000000'"

--- a/tests/unit/plugins/modules/test_clickhouse_settings_profiles.py
+++ b/tests/unit/plugins/modules/test_clickhouse_settings_profiles.py
@@ -38,23 +38,23 @@ def test_setup_object(settings_profile):
         (None, None, None, 'CREATE SETTINGS PROFILE `test_profile`'),
         (None, ['web'], None, 'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`'),
         (None, ['web', 'app'], None, 'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, INHERIT `app`'),
-        ({'max_memory': {'value': '1G'}}, None, None, 'CREATE SETTINGS PROFILE `test_profile` SETTINGS max_memory=\'1G\''),
+        ({'max_memory': {'value': '1G'}}, None, None, 'CREATE SETTINGS PROFILE `test_profile` SETTINGS max_memory=\'1000000000\''),
         (
             {'max_memory': {'value': '1G'}, 'max_threads': {'value': '1'}},
             None, None,
-            'CREATE SETTINGS PROFILE `test_profile` SETTINGS max_memory=\'1G\', max_threads=\'1\''),
+            'CREATE SETTINGS PROFILE `test_profile` SETTINGS max_memory=\'1000000000\', max_threads=\'1\''),
         (
             {'max_memory': {'value': '1G'}, 'max_threads': {'value': '1'}},
             ['web'], None,
-            'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, max_memory=\'1G\', max_threads=\'1\''),
+            'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, max_memory=\'1000000000\', max_threads=\'1\''),
         (
             {'max_memory': {'value': '1G'}, 'max_threads': {'value': '1'}},
             ['web', 'app'], None,
-            'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, INHERIT `app`, max_memory=\'1G\', max_threads=\'1\''),
+            'CREATE SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, INHERIT `app`, max_memory=\'1000000000\', max_threads=\'1\''),
         (
             {'max_memory': {'value': '1G'}, 'max_threads': {'value': '1'}},
             ['web', 'app'], 'cluster',
-            'CREATE SETTINGS PROFILE `test_profile` ON CLUSTER `cluster` SETTINGS INHERIT `web`, INHERIT `app`, max_memory=\'1G\', max_threads=\'1\''),
+            'CREATE SETTINGS PROFILE `test_profile` ON CLUSTER `cluster` SETTINGS INHERIT `web`, INHERIT `app`, max_memory=\'1000000000\', max_threads=\'1\''),
     ]
 )
 def test_create_profile(mock_execute, settings_profile, settings, profiles, cluster, expected):
@@ -95,7 +95,7 @@ def test_alter_profile_changed_inherit_and_settings(settings_profile, mock_execu
     actual_query = get_executed_query(mock_execute)
     assert changed is True
     assert mock_execute.call_count == 1
-    assert actual_query == "ALTER SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, max_memory_usage='10G'"
+    assert actual_query == "ALTER SETTINGS PROFILE `test_profile` SETTINGS INHERIT `web`, max_memory_usage='10000000000'"
 
 
 def test_alter_profile_changed_many_inherit_and_settings_with_cluster(settings_profile, mock_execute):
@@ -106,7 +106,7 @@ def test_alter_profile_changed_many_inherit_and_settings_with_cluster(settings_p
     assert mock_execute.call_count == 1
     assert actual_query == (
         "ALTER SETTINGS PROFILE `test_profile` ON CLUSTER `cluster` "
-        "SETTINGS INHERIT `web`, INHERIT `app`, max_memory_usage='10G', max_threads='1'"
+        "SETTINGS INHERIT `web`, INHERIT `app`, max_memory_usage='10000000000', max_threads='1'"
     )
 
 

--- a/tests/unit/plugins/modules/test_clickhouse_user.py
+++ b/tests/unit/plugins/modules/test_clickhouse_user.py
@@ -197,7 +197,7 @@ def test_create_user_using_dict_settings(user, mock_execute):
         'listed_only', None, 'listed_only',
         None, [])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER `alice` SETTINGS max_memory_usage='10G'"
+    assert actual_query == "CREATE USER `alice` SETTINGS max_memory_usage='10000000000'"
 
 
 def test_create_user_using_profiles_prameter(user, mock_execute):
@@ -217,7 +217,7 @@ def test_create_user_using_profiles_parameter_and_settings(user, mock_execute):
         'listed_only', None, 'listed_only',
         None, ['app', 'web'])
     actual_query = get_executed_query(mock_execute)
-    assert actual_query == "CREATE USER `alice` SETTINGS PROFILE 'app', PROFILE 'web', max_memory_usage='10G'"
+    assert actual_query == "CREATE USER `alice` SETTINGS PROFILE 'app', PROFILE 'web', max_memory_usage='10000000000'"
 
 
 def test_create_user_using_profiles_parameter_and_settings_complex(user, mock_execute):
@@ -235,7 +235,7 @@ def test_create_user_using_profiles_parameter_and_settings_complex(user, mock_ex
         "CREATE USER `alice` SETTINGS PROFILE 'app', "
         "PROFILE 'web', PROFILE 'test_profile', "
         "PROFILE 'web2', "
-        "max_memory_usage='10G' MIN '1G' MAX '100G' CONST, "
+        "max_memory_usage='10000000000' MIN '1000000000' MAX '100000000000' CONST, "
         "allow_experimental_variant_type='1' WRITABLE")
 
 
@@ -274,7 +274,7 @@ def test_alter_user_setting_added(user_exist, mock_execute):
     assert changed is True
     assert actual_query == (
         "ALTER USER `alice` SETTINGS "
-        "max_memory_usage='10G' MIN '1G' MAX '100G' CONST")
+        "max_memory_usage='10000000000' MIN '1000000000' MAX '100000000000' CONST")
 
 
 def test_alter_user_old_setting_added(user_exist, mock_execute):


### PR DESCRIPTION
##### SUMMARY
Database stores settings corresponding to data in bytes format. Improve idempotency by converting K|M|G|T to 1000 based and Ki|Mi|Gi|Ti to 1024 based before comparingsetting.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
settings

##### ADDITIONAL INFORMATION
