### PR TITLE
refactor(quota): fetch current state with systable

### DIFF
--- a/changelogs/fragments/226-refactor-build-quota-current-state.yml
+++ b/changelogs/fragments/226-refactor-build-quota-current-state.yml
@@ -1,2 +1,4 @@
 minor_changes:
-  - clickhouse_quota - refactor fetching current state of existing quota. Move fully to system tables instead of parsing create query. Fix interval idempotency. Since now interval units will be converted to seconds before executing query. (https://github.com/ansible-collections/community.clickhouse/issues/226)
+  - clickhouse_quota - refactor fetching current state of existing quota. Move fully to system tables instead of parsing create query.
+bugfixes:
+  - clickhouse_quota - fix interval idempotency. Since now interval units will be converted to seconds before executing query. (https://github.com/ansible-collections/community.clickhouse/issues/226)

--- a/changelogs/fragments/226-refactor-build-quota-current-state.yml
+++ b/changelogs/fragments/226-refactor-build-quota-current-state.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - clickhouse_quota - refactor fetching current state of existing quota. Move fully to system tables instead of parsing create query. Fix interval idempotency. Since now interval units will be converted to seconds before executing query. (https://github.com/ansible-collections/community.clickhouse/issues/226)

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -29,6 +29,7 @@ version_added: '1.1.0'
 
 author:
   - John Garland (@johnnyg)
+  - Rafal Kozlowski (@rkozlo)
 
 extends_documentation_fragment:
   - community.clickhouse.client_inst_opts
@@ -206,32 +207,6 @@ from ansible_collections.community.clickhouse.plugins.module_utils.clickhouse im
     cluster_argument_spec,
 )
 
-
-_POSSIBLY_ESCAPED_NAME_REGEX = r"(?:`(?:[^`]+)`)|(?:\w+)"
-_KEYED_BY_VALUES = [
-    "user_name",
-    "ip_address",
-    "client_key, ?user_name",
-    "client_key, ?ip_address",
-    "client_key",  # needs to be after so it doesn't match first
-]
-_CREATE_QUOTA_REGEX = re.compile(
-    rf"^CREATE QUOTA (?P<name>{_POSSIBLY_ESCAPED_NAME_REGEX})"
-    rf"(?: ON CLUSTER (?P<cluster>{_POSSIBLY_ESCAPED_NAME_REGEX}))?"
-    rf"(?: KEYED BY (?P<keyed_by>{'|'.join(_KEYED_BY_VALUES)}))?"
-)
-
-_NUMBER_REGEX = r"(?:-?\d+\.?\d*)"
-_INTERVAL_UNITS = [
-    "second",
-    "minute",
-    "hour",
-    "day",
-    "week",
-    "month",
-    "quarter",
-    "year",
-]
 _MAX_LIMIT_TYPES = [
     "queries",
     "query_selects",
@@ -245,22 +220,8 @@ _MAX_LIMIT_TYPES = [
     "execution_time",
     "failed_sequential_authentications",
 ]
-_LIMIT_TYPES = [
-    rf"(?:MAX(?:,? (?:{'|'.join(_MAX_LIMIT_TYPES)}) = {_NUMBER_REGEX})+)",
-    "NO LIMITS",
-    "TRACKING ONLY",
-]
-_LIMITS_REGEX = re.compile(
-    r"FOR (?:(?P<randomized>RANDOMIZED) )?"
-    rf"INTERVAL (?P<interval_number>{_NUMBER_REGEX}) (?P<interval_unit>{'|'.join(_INTERVAL_UNITS)}) "
-    rf"(?P<limit_type>{'|'.join(_LIMIT_TYPES)})"
-)
 
-_ROLES_REGEX = rf"(?:(?:{_POSSIBLY_ESCAPED_NAME_REGEX})(?:, )?)+"
-_APPLY_TO_TYPES = [rf"(?:{_ROLES_REGEX})", "ALL", rf"ALL EXCEPT (?:{_ROLES_REGEX})"]
-_APPLY_TO_REGEX = re.compile(rf" TO (?P<apply_to>{'|'.join(_APPLY_TO_TYPES)})$")
-_USER_OR_ROLE_REGEX = re.compile(rf"(?P<name>{_POSSIBLY_ESCAPED_NAME_REGEX})(?:, ?)?")
-
+_LIMITS_INTERVAL = re.compile(r'^(?P<number>[\d]+) (?P<unit>second|minute|hour|day|week|month|quarter|year)$')
 
 _DEFAULT_LIMIT_PARAMS = {
     "randomized_start": False,
@@ -301,36 +262,129 @@ class ClickHouseQuota:
         self.module = module
         self.client = client
         self.name = name
+        self.keyed_by = None
+        self.durations = None
+        self.apply_to_all = None
+        self.apply_to_except = None
 
         self._exists = None
+        self._quota_limits = []
+        self._loaded = False
 
     @property
     def exists(self):
         if self._exists is None:
-            query = "SELECT 1 FROM system.quotas WHERE name = %(name)s LIMIT 1"
+            query = "SELECT keys, durations, apply_to_all, apply_to_list, apply_to_except FROM system.quotas WHERE name = %(name)s LIMIT 1"
             query_parameters = {'params': {'name': self.name}}
             result = execute_query(self.module, self.client, query, query_parameters)
-            self._exists = bool(result)
+            if bool(result):
+                self._exists = True
+                self.keyed_by, self.durations, self.apply_to_all, self.apply_to_list, self.apply_to_except = result[0]
+            else:
+                self._exists = False
+            # We can simply skip later checks here.
+            if self.durations == [] and self._exists:
+                self._loaded = True
         return self._exists
 
-    def _get_create_statement(self):
-        """Get current definition using SHOW CREATE X"""
-        if not self.exists:
-            return None
+    @property
+    def quota_limits(self):
+        if not self._loaded:
+            self._load()
+        return self._quota_limits
 
-        query = f"SHOW CREATE QUOTA `{self.name}`"
-        result = execute_query(self.module, self.client, query)
-        if result:
-            # SHOW CREATE X returns single row with CREATE statement
-            return result[0][0]
-        return None
+    def _load(self):
+        columns = ['duration', 'is_randomized_interval'] + [f'max_{t}' for t in _MAX_LIMIT_TYPES]
+        query = f"""SELECT
+                        {', '.join(columns)}
+                    FROM system.quota_limits
+                    WHERE quota_name = %(name)s ORDER BY `duration`"""
+        query_parameters = {'params': {'name': self.name}}
+        result = execute_query(self.module, self.client, query, query_parameters)
+
+        for entry in result:
+            (duration, is_randomized_interval, *max_values) = entry
+            max_dict = dict(zip(_MAX_LIMIT_TYPES, max_values))
+            limit = {
+                'max': max_dict,
+                'randomized_start': bool(is_randomized_interval),
+                'interval': duration,
+            }
+            if all(v is None for v in max_dict.values()):
+                limit['tracking_only'] = True
+            self._quota_limits.append(limit)
+        self._loaded = True
+
+    def _build_current_vals_to_compare(self):
+        '''Method to replace old parse over show create statement.
+        In future probably should be changed if further logic will change.
+        '''
+        result = {"limits": []}
+        if self.quota_limits:
+            for entry in self.quota_limits:
+                rewritten_limit = {}
+                # interval in system.quota_limits is seconds -> represent as "<n> second"
+                interval = entry.get("interval")
+                rewritten_limit["interval"] = f"{int(interval)} second"
+
+                rewritten_limit["randomized_start"] = bool(entry.get("randomized_start", False))
+
+                # copy max values, keeping only non-None entries
+                max_dict = entry.get("max") or {}
+                filtered_max = {k: v for k, v in max_dict.items() if v is not None}
+                if filtered_max:
+                    rewritten_limit["max"] = filtered_max
+                else:
+                    rewritten_limit["max"] = {}
+                    rewritten_limit["tracking_only"] = True
+
+                rewritten_limit["no_limits"] = None
+
+                result["limits"].append(rewritten_limit)
+
+        # keyed_by may be array or string
+        if self.keyed_by:
+            if isinstance(self.keyed_by, (list, tuple)):
+                result["keyed_by"] = ",".join(self.keyed_by)
+            else:
+                result["keyed_by"] = str(self.keyed_by)
+
+        # apply_to handling: map system columns to apply_to_mode + apply_to list
+        if self.apply_to_all and self.apply_to_except:
+            result["apply_to_mode"] = "all_except_listed"
+            result["apply_to"] = list(self.apply_to_except or [])
+        elif self.apply_to_all:
+            result["apply_to_mode"] = "all"
+        elif self.apply_to_list:
+            result["apply_to_mode"] = "listed_only"
+            result["apply_to"] = list(self.apply_to_list or [])
+
+        # keep same ordering as normalize expects
+        result["limits"].sort(key=itemgetter("interval"))
+        return result
+
+    def _normalize_interval(self, input):
+        '''Normalize passed interval into seconds.'''
+        _INTERVAL_CONV = {
+            "second": 1,
+            "minute": 60,
+            "hour": 3600,
+            "day": 86400,
+            "week": 604800,
+            "month": 2629746,
+            "quarter": 7889238,
+            "year": 31556952,
+        }
+        match = _LIMITS_INTERVAL.match(input)
+        if not match:
+            self.module.fail_json(msg=f"Unexpected interval input {input}.")
+        return int(match.group('number')) * int(_INTERVAL_CONV[match.group('unit')])
 
     def _needs_altering(self):
         """Check if we need to alter to reach desired"""
-        create_statement = self._get_create_statement()
-        if create_statement is None:
+        if not self.exists:
             return True
-        current_params = self._normalize(self._parse_create_statement(create_statement))
+        current_params = self._normalize(self._build_current_vals_to_compare())
         desired_params = self._normalize(self.module.params)
 
         # For debugging version compatibility issues
@@ -406,60 +460,7 @@ class ClickHouseQuota:
 
         return changed
 
-    @staticmethod
-    def _parse_create_statement(create_statement):
-        match = _CREATE_QUOTA_REGEX.match(create_statement)
-        if not match:
-            raise ValueError(f"Could not parse '{create_statement}'")
-        params = {} | match.groupdict()
-        params.pop("name")
-        cluster = params["cluster"]
-        if cluster is not None:
-            params["cluster"] = cluster.strip("`")
-        next_search_pos = match.end()
-        limits = []
-        for match in _LIMITS_REGEX.finditer(create_statement, pos=next_search_pos):
-            limit = {}
-            groups = match.groupdict()
-            limit["randomized_start"] = groups["randomized"] == "RANDOMIZED"
-            limit["interval"] = f"{groups['interval_number']} {groups['interval_unit']}"
-            limit_type = groups["limit_type"]
-            if limit_type == "NO LIMITS":
-                limit["no_limits"] = True
-            elif limit_type == "TRACKING ONLY":
-                limit["tracking_only"] = True
-            elif limit_type.startswith("MAX "):
-                max_limits = {}
-                for max_limit in limit_type[len("MAX ") :].split(", "):
-                    key, _part, value = max_limit.partition(" = ")
-                    type_fn = float if key == "execution_time" else int
-                    max_limits[key] = type_fn(value)
-                limit["max"] = max_limits
-            else:
-                raise ValueError(f"Invalid limit type '{limit_type}'")
-            limits.append(limit)
-            next_search_pos = match.end()
-        params["limits"] = limits
-        match = _APPLY_TO_REGEX.match(create_statement, pos=next_search_pos)
-        if match:
-            groups = match.groupdict()
-            apply_to = groups["apply_to"]
-            if apply_to == "ALL":
-                params["apply_to_mode"] = "all"
-                apply_to = ""
-            elif apply_to.startswith("ALL EXCEPT "):
-                params["apply_to_mode"] = "all_except_listed"
-                apply_to = apply_to[len("ALL EXCEPT ") :]
-            else:
-                params["apply_to_mode"] = "listed_only"
-            params["apply_to"] = [
-                match.groupdict()["name"].strip("`")
-                for match in _USER_OR_ROLE_REGEX.finditer(apply_to)
-            ]
-        return params
-
-    @staticmethod
-    def _normalize(params):
+    def _normalize(self, params):
         normalized = _DEFAULT_PARAMS.copy()
         for key in normalized.keys() & params.keys():
             value = params[key]
@@ -471,6 +472,8 @@ class ClickHouseQuota:
                         for limit_key in normalized_limit.keys() & limit_params.keys():
                             limit_value = limit_params[limit_key]
                             if limit_value is not None:
+                                if limit_key == 'interval':
+                                    limit_value = self._normalize_interval(limit_value)
                                 normalized_limit[limit_key] = limit_value
                         normalized_limits.append(normalized_limit)
                     normalized[key] = normalized_limits
@@ -514,7 +517,8 @@ class ClickHouseQuota:
             sql_clause = ["FOR"]
             if limit.get("randomized_start", False):
                 sql_clause.append("RANDOMIZED")
-            sql_clause.append(f"INTERVAL {limit['interval']}")
+            normalized_interval = self._normalize_interval(limit['interval'])
+            sql_clause.append(f"INTERVAL {normalized_interval} second")
             max_limits = {
                 key: value
                 for key, value in (limit.get("max") or {}).items()

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -221,7 +221,7 @@ _MAX_LIMIT_TYPES = [
     "failed_sequential_authentications",
 ]
 
-_LIMITS_INTERVAL = re.compile(r'^(?P<number>[\d]+) (?P<unit>second|minute|hour|day|week|month|quarter|year)$', re.IGNORECASE)
+_LIMITS_INTERVAL = re.compile(r'^(?P<number>[\d]+(\.[\d]+)?) (?P<unit>second|minute|hour|day|week|month|quarter|year)$', re.IGNORECASE)
 
 _DEFAULT_LIMIT_PARAMS = {
     "randomized_start": False,
@@ -378,7 +378,8 @@ class ClickHouseQuota:
         match = _LIMITS_INTERVAL.match(input)
         if not match:
             self.module.fail_json(msg=f"Unexpected interval input {input}.")
-        return int(match.group('number')) * int(_INTERVAL_CONV[match.group('unit').lower()])
+        # Input interval can be fractional. The result clickhouse
+        return int(float(match.group('number')) * int(_INTERVAL_CONV[match.group('unit').lower()]))
 
     def _needs_altering(self):
         """Check if we need to alter to reach desired"""

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -363,7 +363,7 @@ class ClickHouseQuota:
         result["limits"].sort(key=itemgetter("interval"))
         return result
 
-    def _normalize_interval(self, input):
+    def _normalize_interval(self, interval):
         '''Normalize passed interval into seconds.'''
         _INTERVAL_CONV = {
             "second": 1,
@@ -375,9 +375,9 @@ class ClickHouseQuota:
             "quarter": 7889238,
             "year": 31556952,
         }
-        match = _LIMITS_INTERVAL.match(input)
+        match = _LIMITS_INTERVAL.match(interval)
         if not match:
-            self.module.fail_json(msg=f"Unexpected interval input {input}.")
+            self.module.fail_json(msg=f"Unexpected interval input {interval}.")
         # Input interval can be fractional. The result clickhouse
         return int(float(match.group('number')) * int(_INTERVAL_CONV[match.group('unit').lower()]))
 

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -266,6 +266,7 @@ class ClickHouseQuota:
         self.keyed_by = None
         self.durations = None
         self.apply_to_all = None
+        self.apply_to_list = None
         self.apply_to_except = None
 
         self._exists = None

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -361,8 +361,6 @@ class ClickHouseQuota:
             result["apply_to_mode"] = "listed_only"
             result["apply_to"] = list(self.apply_to_list or [])
 
-        # keep same ordering as normalize expects
-        result["limits"].sort(key=itemgetter("interval"))
         return result
 
     def _normalize_interval(self, interval):

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -186,6 +186,7 @@ RETURN = r"""
 executed_statements:
   description:
   - Data-modifying executed statements.
+  - Interval will be converted and passed to database in seconds.
   returned: on success
   type: list
   sample: ['CREATE QUOTA test_quota']

--- a/plugins/modules/clickhouse_quota.py
+++ b/plugins/modules/clickhouse_quota.py
@@ -221,7 +221,7 @@ _MAX_LIMIT_TYPES = [
     "failed_sequential_authentications",
 ]
 
-_LIMITS_INTERVAL = re.compile(r'^(?P<number>[\d]+) (?P<unit>second|minute|hour|day|week|month|quarter|year)$')
+_LIMITS_INTERVAL = re.compile(r'^(?P<number>[\d]+) (?P<unit>second|minute|hour|day|week|month|quarter|year)$', re.IGNORECASE)
 
 _DEFAULT_LIMIT_PARAMS = {
     "randomized_start": False,
@@ -378,7 +378,7 @@ class ClickHouseQuota:
         match = _LIMITS_INTERVAL.match(input)
         if not match:
             self.module.fail_json(msg=f"Unexpected interval input {input}.")
-        return int(match.group('number')) * int(_INTERVAL_CONV[match.group('unit')])
+        return int(match.group('number')) * int(_INTERVAL_CONV[match.group('unit').lower()])
 
     def _needs_altering(self):
         """Check if we need to alter to reach desired"""

--- a/tests/integration/targets/clickhouse_quota/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_quota/tasks/initial.yml
@@ -43,7 +43,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 5 minute MAX queries = 10']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 300 second MAX queries = 10']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -74,7 +74,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 5 minute MAX queries = 100, execution_time = 600.0 TO default']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 300 second MAX queries = 100, execution_time = 600.0 TO default']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -102,7 +102,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 5 minute TRACKING ONLY TO ALL']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 300 second TRACKING ONLY TO ALL']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -130,7 +130,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 5 minute NO LIMITS TO ALL']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 300 second NO LIMITS TO ALL']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -162,7 +162,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 5 minute MAX failed_sequential_authentications = 5 TO ALL EXCEPT admin, CURRENT_USER']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` FOR INTERVAL 300 second MAX failed_sequential_authentications = 5 TO ALL EXCEPT admin, CURRENT_USER']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -194,7 +194,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` KEYED BY user_name FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 300.5 TO ALL']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` KEYED BY user_name FOR RANDOMIZED INTERVAL 300 second MAX queries = 100, execution_time = 300.5 TO ALL']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -230,7 +230,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` ON CLUSTER `test_cluster` KEYED BY user_name FOR RANDOMIZED INTERVAL 5 minute MAX execution_time = 10.2, FOR INTERVAL 1 day MAX query_selects = 10, query_inserts = 10 TO CURRENT_USER']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` ON CLUSTER `test_cluster` KEYED BY user_name FOR RANDOMIZED INTERVAL 300 second MAX execution_time = 10.2, FOR INTERVAL 86400 second MAX query_selects = 10, query_inserts = 10 TO CURRENT_USER']
 
 - name: Check the quota was not created in check mode
   register: result
@@ -275,7 +275,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `test_quota` KEYED BY user_name FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100 TO default']
+    - result.executed_statements == ['CREATE QUOTA `test_quota` KEYED BY user_name FOR RANDOMIZED INTERVAL 300 second MAX queries = 100 TO default']
 
 - name: Check the quota was actually created with the correct parameters
   register: result
@@ -350,7 +350,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['CREATE QUOTA `tést quota` KEYED BY client_key,user_name FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 1.1 TO default']
+    - result.executed_statements == ['CREATE QUOTA `tést quota` KEYED BY client_key,user_name FOR RANDOMIZED INTERVAL 300 second MAX queries = 100, execution_time = 1.1 TO default']
 
 - name: Check the quota was actually created with the correct parameters
   register: result
@@ -383,7 +383,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ['ALTER QUOTA `tést quota` KEYED BY client_key,user_name FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 1.1, FOR INTERVAL 1 minute MAX errors = 10 TO default']
+    - result.executed_statements == ['ALTER QUOTA `tést quota` KEYED BY client_key,user_name FOR RANDOMIZED INTERVAL 300 second MAX queries = 100, execution_time = 1.1, FOR INTERVAL 60 second MAX errors = 10 TO default']
 
 - name: Check the quota was not actually altered
   register: result
@@ -489,7 +489,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE QUOTA `test_quota` FOR INTERVAL 1 day MAX errors = 1000 TO ALL"]
+    - result.executed_statements == ["CREATE QUOTA `test_quota` FOR INTERVAL 86400 second MAX errors = 1000 TO ALL"]
 
 - name: Check the quota was actually created with the correct parameters
   register: result
@@ -612,7 +612,7 @@
   ansible.builtin.assert:
     that:
     - result is changed
-    - result.executed_statements == ["CREATE QUOTA `test_quota` FOR INTERVAL 15 minute TRACKING ONLY TO ALL"]
+    - result.executed_statements == ["CREATE QUOTA `test_quota` FOR INTERVAL 900 second TRACKING ONLY TO ALL"]
 
 - name: Check the quota was actually created with the correct parameters
   register: result

--- a/tests/integration/targets/clickhouse_quota/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_quota/tasks/initial.yml
@@ -4,7 +4,7 @@
 #####################################################################
 
 # Basic creation in check mode
-- name: Create a test quota in check mode
+- name: Create a no limits test quota in check mode
   register: result
   check_mode: true
   community.clickhouse.clickhouse_quota:
@@ -26,6 +26,46 @@
   ansible.builtin.assert:
     that:
     - result.result == []
+
+- name: Create a no limits test quota in real mode
+  register: result
+  community.clickhouse.clickhouse_quota:
+    state: present
+    name: test_quota
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ['CREATE QUOTA `test_quota`']
+
+- name: Check the quota was created in check mode
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT 1 FROM system.quotas WHERE name = 'test_quota'"
+
+- name: Verify that the quota is present
+  ansible.builtin.assert:
+    that:
+    - result.result == [[1]]
+
+- name: Alter a no limits test quota adding keyed by in real mode
+  register: result
+  community.clickhouse.clickhouse_quota:
+    state: present
+    name: test_quota
+    keyed_by: user_name
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is changed
+    - result.executed_statements == ['ALTER QUOTA `test_quota` KEYED BY user_name']
+
+- name: Drop test quota
+  community.clickhouse.clickhouse_quota:
+    state: absent
+    name: test_quota
 
 # Basic creation with limits in check mode
 - name: Create a test quota in check mode

--- a/tests/integration/targets/clickhouse_quota/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_quota/tasks/initial.yml
@@ -719,3 +719,73 @@
   ansible.builtin.assert:
     that:
     - result.result == []
+
+- name: Create quota with factional interval - 1
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 1.5 year
+        tracking_only: true
+    apply_to_mode: all
+
+- name: Check the quota was interval value
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT duration FROM system.quota_limits WHERE quota_name = 'test_quota'"
+
+- name: Verify quota duration
+  ansible.builtin.assert:
+    that:
+    - result.result == [[47335428]]
+
+- name: Create quota with factional interval - 1 - idempotency
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 1.5 year
+        tracking_only: true
+    apply_to_mode: all
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+
+- name: Drop quota
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    state: absent
+
+- name: Create quota with factional interval - 2
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 0.1 day
+        tracking_only: true
+    apply_to_mode: all
+  register: result
+
+- name: Check the quota was interval value
+  register: result
+  community.clickhouse.clickhouse_client:
+    execute: "SELECT duration FROM system.quota_limits WHERE quota_name = 'test_quota'"
+
+- name: Verify quota duration
+  ansible.builtin.assert:
+    that:
+    - result.result == [[8640]]
+
+- name: Create quota with factional interval - 2 - idempotency
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 0.1 day
+        tracking_only: true
+    apply_to_mode: all
+  register: result
+
+- name: Drop quota
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    state: absent

--- a/tests/integration/targets/clickhouse_quota/tasks/initial.yml
+++ b/tests/integration/targets/clickhouse_quota/tasks/initial.yml
@@ -785,6 +785,39 @@
     apply_to_mode: all
   register: result
 
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+
+- name: Create quota with test case sensitivity
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 0.1 DAY
+        tracking_only: true
+    apply_to_mode: all
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+
+- name: Create quota with test case sensitivity - 2
+  community.clickhouse.clickhouse_quota:
+    name: test_quota
+    limits:
+      - interval: 0.1 Day
+        tracking_only: true
+    apply_to_mode: all
+  register: result
+
+- name: Check the return values
+  ansible.builtin.assert:
+    that:
+    - result is not changed
+
 - name: Drop quota
   community.clickhouse.clickhouse_quota:
     name: test_quota

--- a/tests/unit/plugins/modules/test_clickhouse_quota.py
+++ b/tests/unit/plugins/modules/test_clickhouse_quota.py
@@ -110,16 +110,22 @@ def test_properties_loading_check_quota_limits(quota, mocker):
 @pytest.mark.parametrize(
     'input,expected',
     [
+        ("0 second", 0),
         ("1 second", 1),
         ("1 SECOND", 1),
         ("2 second", 2),
+        ("2.3 second", 2),
+        ("2.6 second", 2),
         ("1 minute", 60),
+        ("1.5 minute", 90),
         ("2 minute", 120),
         ("2 hour", 7200),
+        ("0.1 day", 8640),
         ("2 day", 172800),
         ("2 week", 1209600),
         ("2 month", 5259492),
         ("2 quarter", 15778476),
+        ("1.5 year", 47335428),
         ("2 year", 63113904),
     ]
 )

--- a/tests/unit/plugins/modules/test_clickhouse_quota.py
+++ b/tests/unit/plugins/modules/test_clickhouse_quota.py
@@ -3,269 +3,129 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 import pytest
 from ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota import (
-    _APPLY_TO_REGEX,
-    _CREATE_QUOTA_REGEX,
-    _LIMITS_REGEX,
     ClickHouseQuota,
-)
-from ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota import (
     _DEFAULT_PARAMS as DEFAULT_NORMALIZE_PARAMS,
 )
 
 
-@pytest.mark.parametrize(
-    argnames="search",
-    argvalues=[
-        "",
-        "CREATE NOT_QUOTA foo",
-    ],
-)
-def test_negative_create_quota_regex(search):
-    match = _CREATE_QUOTA_REGEX.match(search)
-    assert match is None
+@pytest.fixture
+def quota(mocker):
+    mock_module = mocker.MagicMock()
+    mock_module.check_mode = False
+    mock_client = mocker.MagicMock()
+
+    return ClickHouseQuota(module=mock_module, client=mock_client, name="test_quota")
 
 
-DEFAULT_CREATE_QUOTA_GROUPS = dict(
-    name=None,
-    cluster=None,
-    keyed_by=None,
-)
+def test_setup_object(quota):
+    assert quota.name == 'test_quota'
+    assert quota._exists is None
 
 
-@pytest.mark.parametrize(
-    argnames="search,expected",
-    argvalues=[
-        ("CREATE QUOTA test_quota", dict(name="test_quota")),
-        ("CREATE QUOTA `test_quota`", dict(name="`test_quota`")),
-        ("CREATE QUOTA `test quota`", dict(name="`test quota`")),
-        ("CREATE QUOTA `tést_quota`", dict(name="`tést_quota`")),
-        ("CREATE QUOTA `tést quota`", dict(name="`tést quota`")),
-        (
-            "CREATE QUOTA test_quota ON CLUSTER test_cluster",
-            dict(name="test_quota", cluster="test_cluster"),
-        ),
-        (
-            "CREATE QUOTA test_quota ON CLUSTER `test cluster`",
-            dict(name="test_quota", cluster="`test cluster`"),
-        ),
-        (
-            "CREATE QUOTA test_quota ON CLUSTER `tést_cluster`",
-            dict(name="test_quota", cluster="`tést_cluster`"),
-        ),
-        (
-            "CREATE QUOTA test_quota ON CLUSTER `tést cluster`",
-            dict(name="test_quota", cluster="`tést cluster`"),
-        ),
-        (
-            "CREATE QUOTA `tést quota` ON CLUSTER `tést cluster`",
-            dict(name="`tést quota`", cluster="`tést cluster`"),
-        ),
-        (
-            "CREATE QUOTA test_quota KEYED BY user_name",
-            dict(name="test_quota", keyed_by="user_name"),
-        ),
-        ("CREATE QUOTA test_quota KEYED BY non_existent_key", dict(name="test_quota")),
-        (
-            "CREATE QUOTA `tést quota` KEYED BY ip_address",
-            dict(name="`tést quota`", keyed_by="ip_address"),
-        ),
-        (
-            "CREATE QUOTA `tést quota` ON CLUSTER `tést cluster` KEYED BY client_key,ip_address",
-            dict(
-                name="`tést quota`",
-                cluster="`tést cluster`",
-                keyed_by="client_key,ip_address",
-            ),
-        ),
-    ],
-)
-def test_create_quota_regex(search, expected):
-    match = _CREATE_QUOTA_REGEX.match(search)
-    assert match is not None
-    actual = match.groupdict()
-    assert actual == (DEFAULT_CREATE_QUOTA_GROUPS | expected)
+def test_not_exists_loading(quota, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.execute_query",
+        return_value=[])
+    assert quota.exists is False
+    assert quota._loaded is False
+    assert quota.keyed_by is None
+    assert quota.durations is None
+    assert quota.apply_to_all is None
+    assert quota.apply_to_except is None
+    assert quota._quota_limits == []
 
 
-DEFAULT_LIMITS_GROUPS = dict(
-    randomized=None,
-    interval_number=None,
-    interval_unit=None,
-    limit_type=None,
-)
+def test_exists_loading(quota, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.execute_query",
+        return_value=[(['user_name'], [3600], 0, ['test'], ['except'])])
+    assert quota.exists is True
+    assert quota._loaded is False
+    assert quota.keyed_by == ['user_name']
+    assert quota.durations == [3600]
+    assert quota.apply_to_all == 0
+    assert quota.apply_to_list == ['test']
+    assert quota.apply_to_except == ['except']
+    assert quota._quota_limits == []
 
 
-@pytest.mark.parametrize(
-    argnames="search,expected",
-    argvalues=[
-        (
-            "FOR INTERVAL 5 minute NO LIMITS",
-            {
-                "interval_number": "5",
-                "interval_unit": "minute",
-                "limit_type": "NO LIMITS",
-            },
-        ),
-        (
-            "FOR RANDOMIZED INTERVAL 0.25 year TRACKING ONLY",
-            {
-                "randomized": "RANDOMIZED",
-                "interval_number": "0.25",
-                "interval_unit": "year",
-                "limit_type": "TRACKING ONLY",
-            },
-        ),
-        (
-            "FOR INTERVAL 1 day MAX queries = 100",
-            {
-                "interval_number": "1",
-                "interval_unit": "day",
-                "limit_type": "MAX queries = 100",
-            },
-        ),
-        (
-            "FOR INTERVAL 1 day MAX query_selects = 80, query_inserts = 20",
-            {
-                "interval_number": "1",
-                "interval_unit": "day",
-                "limit_type": "MAX query_selects = 80, query_inserts = 20",
-            },
-        ),
-        (
-            "FOR RANDOMIZED INTERVAL 1000 second MAX execution_time = 100.5, failed_sequential_authentications = 10",
-            {
-                "randomized": "RANDOMIZED",
-                "interval_number": "1000",
-                "interval_unit": "second",
-                "limit_type": "MAX execution_time = 100.5, failed_sequential_authentications = 10",
-            },
-        ),
-    ],
-)
-def test_limits_regex(search, expected):
-    match = _LIMITS_REGEX.match(search)
-    assert match is not None
-    actual = match.groupdict()
-    assert actual == (DEFAULT_LIMITS_GROUPS | expected)
+def test_properties_loading_empty_limit(quota, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.execute_query",
+        return_value=[(['user_name'], [], 0, ['test'], ['except'])])
+    assert quota.exists is True
+    assert quota._loaded is True
+
+
+def test_properties_loading(quota, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.execute_query",
+        return_value=[(3600, 0, None, None, None, None, None, None, None, None, None, None, None)])
+    quota._load()
+    assert quota._loaded is True
+    assert quota.quota_limits == [{
+        "max": {
+            "queries": None,
+            "query_selects": None,
+            "query_inserts": None,
+            "errors": None,
+            "result_rows": None,
+            "result_bytes": None,
+            "read_rows": None,
+            "read_bytes": None,
+            "written_bytes": None,
+            "execution_time": None,
+            "failed_sequential_authentications": None,
+        },
+        "randomized_start": False,
+        "interval": 3600,
+        "tracking_only": True,
+    }]
+
+
+def test_properties_loading_check_quota_limits(quota, mocker):
+    mocker.patch(
+        "ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.execute_query",
+        return_value=[(3600, 0, 1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009.0, 1010)]
+    )
+    assert quota.quota_limits == [{
+        "max": {
+            "queries": 1000,
+            "query_selects": 1001,
+            "query_inserts": 1002,
+            "errors": 1003,
+            "result_rows": 1004,
+            "result_bytes": 1005,
+            "read_rows": 1006,
+            "read_bytes": 1007,
+            "written_bytes": 1008,
+            "execution_time": 1009.0,
+            "failed_sequential_authentications": 1010,
+        },
+        "randomized_start": False,
+        "interval": 3600,
+    }]
 
 
 @pytest.mark.parametrize(
-    argnames="search,expected",
-    argvalues=[
-        (" TO DEFAULT", dict(apply_to="DEFAULT")),
-        (
-            " TO CURRENT_USER, test_user, `tést user`",
-            dict(apply_to="CURRENT_USER, test_user, `tést user`"),
-        ),
-        (
-            " TO DEFAULT, `tést user`, CURRENT_USER",
-            dict(apply_to="DEFAULT, `tést user`, CURRENT_USER"),
-        ),
-        (" TO ALL", dict(apply_to="ALL")),
-        (" TO ALL EXCEPT CURRENT_USER", dict(apply_to="ALL EXCEPT CURRENT_USER")),
-        (
-            " TO ALL EXCEPT CURRENT_USER, test_user, `tést user`",
-            dict(apply_to="ALL EXCEPT CURRENT_USER, test_user, `tést user`"),
-        ),
-    ],
+    'input,expected',
+    [
+        ("1 second", 1),
+        ("2 second", 2),
+        ("1 minute", 60),
+        ("2 minute", 120),
+        ("2 hour", 7200),
+        ("2 day", 172800),
+        ("2 week", 1209600),
+        ("2 month", 5259492),
+        ("2 quarter", 15778476),
+        ("2 year", 63113904),
+    ]
 )
-def test_apply_to_regex(search, expected):
-    match = _APPLY_TO_REGEX.match(search)
-    assert match is not None
-    actual = match.groupdict()
-    assert actual == expected
-
-
-DEFAULT_PARSE_PARAMS = dict(
-    cluster=None,
-    keyed_by=None,
-    limits=[],
-)
-
-
-@pytest.mark.parametrize(
-    argnames="create_statement,expected",
-    argvalues=[
-        (
-            "CREATE QUOTA test_quota FOR INTERVAL 1 hour TRACKING ONLY TO DEFAULT, `tést user`, CURRENT_USER",
-            {
-                "limits": [
-                    {
-                        "randomized_start": False,
-                        "interval": "1 hour",
-                        "tracking_only": True,
-                    },
-                ],
-                "apply_to": ["DEFAULT", "tést user", "CURRENT_USER"],
-                "apply_to_mode": "listed_only",
-            },
-        ),
-        (
-            "CREATE QUOTA test_quota FOR RANDOMIZED INTERVAL 1 hour NO LIMITS TO ALL",
-            {
-                "limits": [
-                    {
-                        "randomized_start": True,
-                        "interval": "1 hour",
-                        "no_limits": True,
-                    },
-                ],
-                "apply_to": [],
-                "apply_to_mode": "all",
-            },
-        ),
-        (
-            "CREATE QUOTA test_quota ON CLUSTER `tést cluster` KEYED BY client_key,user_name"
-            " FOR RANDOMIZED INTERVAL 1 minute MAX queries = 100, query_selects = 80, query_inserts = 10,"
-            " FOR INTERVAL 1 day MAX execution_time = 3000.5, read_rows = 1024"
-            " TO ALL EXCEPT `tést user`",
-            {
-                "cluster": "tést cluster",
-                "keyed_by": "client_key,user_name",
-                "limits": [
-                    {
-                        "randomized_start": True,
-                        "interval": "1 minute",
-                        "max": {
-                            "queries": 100,
-                            "query_selects": 80,
-                            "query_inserts": 10,
-                        },
-                    },
-                    {
-                        "randomized_start": False,
-                        "interval": "1 day",
-                        "max": {
-                            "execution_time": 3000.5,
-                            "read_rows": 1024,
-                        },
-                    },
-                ],
-                "apply_to": ["tést user"],
-                "apply_to_mode": "all_except_listed",
-            },
-        ),
-        (
-            "CREATE QUOTA tracking_only KEYED BY user_name FOR INTERVAL 15 minute TRACKING ONLY TO ALL",
-            {
-                "keyed_by": "user_name",
-                "limits": [
-                    {
-                        "randomized_start": False,
-                        "interval": "15 minute",
-                        "tracking_only": True,
-                    },
-                ],
-                "apply_to": [],
-                "apply_to_mode": "all",
-            },
-        ),
-    ],
-)
-def test_parse_create_statement(mocker, create_statement, expected):
-    quota = ClickHouseQuota(mocker.MagicMock(), mocker.MagicMock(), "test_quota")
-    quota._exists = True
-    actual = quota._parse_create_statement(create_statement)
-    assert actual == (DEFAULT_PARSE_PARAMS | expected)
+def test_normalize_interval(quota, input, expected):
+    result = quota._normalize_interval(input)
+    assert result == expected
+    quota.module.fail_json.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -286,14 +146,14 @@ def test_parse_create_statement(mocker, create_statement, expected):
             {
                 "limits": [
                     {
-                        "interval": "1 minute",
+                        "interval": 60,
                         "randomized_start": False,
                         "max": {},
                         "no_limits": None,
                         "tracking_only": None,
                     },
                     {
-                        "interval": "5 minute",
+                        "interval": 300,
                         "randomized_start": False,
                         "max": {},
                         "no_limits": None,
@@ -317,7 +177,7 @@ def test_parse_create_statement(mocker, create_statement, expected):
                 "limits": [
                     {
                         "randomized_start": False,
-                        "interval": "1 day",
+                        "interval": 86400,
                         "max": {
                             "queries": 10,
                             "query_selects": None,
@@ -352,7 +212,7 @@ def test_parse_create_statement(mocker, create_statement, expected):
                 "limits": [
                     {
                         "randomized_start": False,
-                        "interval": "1 day",
+                        "interval": 86400,
                         "max": {
                             "errors": 1,
                             "queries": None,
@@ -396,7 +256,7 @@ def test_parse_create_statement(mocker, create_statement, expected):
                 "limits": [
                     {
                         "randomized_start": False,
-                        "interval": "1 day",
+                        "interval": 86400,
                         "max": {},
                         "no_limits": None,
                         "tracking_only": True,
@@ -421,7 +281,7 @@ def test_parse_create_statement(mocker, create_statement, expected):
             {
                 "limits": [
                     {
-                        "interval": "15 minute",
+                        "interval": 900,
                         "max": {},
                         "no_limits": None,
                         "tracking_only": True,
@@ -432,206 +292,6 @@ def test_parse_create_statement(mocker, create_statement, expected):
         ),
     ],
 )
-def test_normalize(params, expected):
-    actual = ClickHouseQuota._normalize(params)
+def test_normalize(params, expected, quota):
+    actual = quota._normalize(params)
     assert actual == (DEFAULT_NORMALIZE_PARAMS | expected)
-
-
-DEFAULT_PARAMS = dict(
-    state="present",
-    cluster=None,
-    keyed_by=None,
-    limits=[],
-    apply_to_mode="listed_only",
-)
-
-
-@pytest.mark.parametrize(
-    argnames="name,params,existing_quota,expected_executed",
-    argvalues=[
-        # create queries
-        ("tést_quota", {}, None, ["CREATE QUOTA `tést_quota`"]),
-        ("tést_quota", {}, "CREATE QUOTA `tést_quota`", []),
-        (
-            "test_quota",
-            {
-                "cluster": "test_cluster",
-                "keyed_by": "user_name",
-                "limits": [
-                    {
-                        "interval": "5 minute",
-                        "max": {
-                            "queries": 100,
-                        },
-                    }
-                ],
-                "apply_to": ["CURRENT_USER"],
-            },
-            None,
-            [
-                "CREATE QUOTA `test_quota` ON CLUSTER `test_cluster` KEYED BY user_name FOR INTERVAL 5 minute MAX queries = 100 TO CURRENT_USER"
-            ],
-        ),
-        # drop queries
-        ("test_quota", dict(state="absent"), None, []),
-        (
-            "test_quota",
-            dict(state="absent"),
-            "CREATE QUOTA 'test_quota'",
-            ["DROP QUOTA `test_quota`"],
-        ),
-        # alter queries
-        (
-            "test_quota",
-            {
-                "cluster": "test_cluster",
-                "keyed_by": "user_name",
-                "limits": [
-                    {
-                        "interval": "5 minute",
-                        "max": {
-                            "queries": 100,
-                        },
-                    }
-                ],
-                "apply_to": ["CURRENT_USER"],
-            },
-            "CREATE QUOTA test_quota",
-            [
-                "ALTER QUOTA `test_quota` ON CLUSTER `test_cluster` KEYED BY user_name FOR INTERVAL 5 minute MAX queries = 100 TO CURRENT_USER"
-            ],
-        ),
-        (
-            "test_quota",
-            {
-                "limits": [
-                    {
-                        "interval": "5 minute",
-                        "max": {
-                            "queries": 100,
-                        },
-                    }
-                ],
-                "apply_to": ["test_user", "CURRENT_USER"],
-            },
-            "CREATE QUOTA test_quota FOR INTERVAL 5 minute MAX queries = 100 TO CURRENT_USER, test_user",
-            [],
-        ),
-        (
-            "tést quota",
-            {
-                "keyed_by": "client_key",
-                "limits": [
-                    {
-                        "randomized_start": True,
-                        "interval": "5 minute",
-                        "max": {
-                            "queries": 100,
-                            "execution_time": 1.1,
-                        },
-                    },
-                    {
-                        "interval": "1 minute",
-                        "max": {
-                            "errors": 10,
-                        },
-                    },
-                ],
-                "apply_to": ["default"],
-            },
-            "CREATE QUOTA `tést quota` KEYED BY client_key, user_name FOR INTERVAL 1 minute MAX errors = 10, "
-            "FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 1.1 TO default",
-            [
-                "ALTER QUOTA `tést quota` KEYED BY client_key FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 1.1, "
-                "FOR INTERVAL 1 minute MAX errors = 10 TO default"
-            ],
-        ),
-        (
-            "tést quota",
-            {
-                "keyed_by": "client_key,user_name",
-                "limits": [
-                    {
-                        "randomized_start": True,
-                        "interval": "5 minute",
-                        "max": {
-                            "queries": 100,
-                            "execution_time": 1.1,
-                        },
-                    },
-                    {
-                        "interval": "1 minute",
-                        "max": {
-                            "errors": 10,
-                        },
-                    },
-                ],
-                "apply_to": ["default"],
-            },
-            "CREATE QUOTA `tést quota` KEYED BY client_key, user_name FOR INTERVAL 1 minute MAX errors = 10, "
-            "FOR RANDOMIZED INTERVAL 5 minute MAX queries = 100, execution_time = 1.1 TO default",
-            [],
-        ),
-        (
-            "test_quota",
-            {
-                "keyed_by": "user_name",
-                "limits": [
-                    {
-                        "interval": "5 minute",
-                        "no_limits": True,
-                    },
-                ],
-            },
-            "CREATE QUOTA test_quota KEYED BY user_name",
-            [],
-        ),
-        (
-            "tracking_only",
-            {
-                "keyed_by": "user_name",
-                "limits": [
-                    {
-                        "interval": "15 minute",
-                        "tracking_only": True,
-                        "no_limits": None,
-                        "max": None,
-                    },
-                ],
-                "apply_to": [],
-                "apply_to_mode": "all",
-            },
-            "CREATE QUOTA tracking_only KEYED BY user_name FOR INTERVAL 15 minute TRACKING ONLY TO ALL",
-            [],
-        ),
-    ],
-)
-def test_ensure_state(mocker, name, params, existing_quota, expected_executed):
-    for check_mode in (True, False):
-        client = mocker.MagicMock()
-        client.execute.return_value = ["1"] if existing_quota else []
-        module = mocker.MagicMock()
-        module._verbosity = 1
-        module.check_mode = check_mode
-        module.params = DEFAULT_PARAMS | params
-        will_run_show_create = existing_quota and module.params["state"] == "present"
-        quota = ClickHouseQuota(module, client, name)
-        quota._exists = bool(existing_quota)
-        client.execute.return_value = [[existing_quota]] if will_run_show_create else []
-        executed_statements = []
-        mocker.patch("ansible_collections.community.clickhouse.plugins.modules.clickhouse_quota.executed_statements",
-                     executed_statements)
-        changed = quota.ensure_state()
-        if check_mode:
-            if will_run_show_create:
-                client.execute.assert_called_once_with(f"SHOW CREATE QUOTA `{name}`")
-            else:
-                client.execute.assert_not_called()
-        else:
-            expected_call_args_list = []
-            if will_run_show_create:
-                expected_call_args_list.append(((f"SHOW CREATE QUOTA `{name}`",),))
-            expected_call_args_list.extend(((sql,),) for sql in expected_executed)
-            assert client.execute.call_args_list == expected_call_args_list
-        assert executed_statements == expected_executed
-        assert changed is bool(expected_executed)

--- a/tests/unit/plugins/modules/test_clickhouse_quota.py
+++ b/tests/unit/plugins/modules/test_clickhouse_quota.py
@@ -111,6 +111,7 @@ def test_properties_loading_check_quota_limits(quota, mocker):
     'input,expected',
     [
         ("1 second", 1),
+        ("1 SECOND", 1),
         ("2 second", 2),
         ("1 minute", 60),
         ("2 minute", 120),


### PR DESCRIPTION
##### SUMMARY
Parsing create query is very fragile and hard to maintaint. Instead of getting create query and parse it with tons of regex move fully to system table like quotas and quota_limits. Easier to keep module idempotent and lower risk of introduced breaking changes with newer clickhouse version.

Normalize interval to seconds always.

Removed completly craft unit test for ensuring state. No point to keep it in such state. During furter module refactor new unit tests with narrow cases will be added.

Fixes #226

